### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,10 +12,10 @@ placeholder	KEYWORD3
 defaultValue	KEYWORD3
 customHtml	KEYWORD3
 
-IotWebConfSeparator    KEYWORD1
+IotWebConfSeparator	KEYWORD1
 
-IotWebConf    KEYWORD1
-setConfigPin    KEYWORD2
+IotWebConf	KEYWORD1
+setConfigPin	KEYWORD2
 setStatusPin	KEYWORD2
 setupUpdateServer	KEYWORD2
 init	KEYWORD2
@@ -28,4 +28,3 @@ setConfigSavedCallback	KEYWORD2
 setFormValidator	KEYWORD2
 addParameter	KEYWORD2
 getThingName	KEYWORD2
-


### PR DESCRIPTION
The Arduino IDE currently requires the use of a single true tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords