### PR TITLE
Correct includes value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,5 +7,4 @@ paragraph=IotWebConf will start up in AP (access point) mode, and provide a conf
 category=Communication
 url=https://github.com/prampec/IotWebConf
 architectures=esp8266
-includes=ESP8266WiFi.h,ESP8266WebServer.h,DNSServer.h
-
+includes=IotWebConf.h


### PR DESCRIPTION
The `includes` field in library.properties is used to specify which `#include` directives should be added to the sketch via **Sketch > Include Library > IotWebConf**. This field should specify the primary header file(s) of the library.

The `includes` field is only used by Arduino IDE 1.6.10 and newer and these IDE versions do not require `#include` directives in the sketch for resolution of dependencies of libraries so having `ESP8266WiFi.h,ESP8266WebServer.h,DNSServer.h` in the `includes` field is not necessary.