### PR TITLE
Fix elapsed time checking

### DIFF
--- a/examples/IotWebConf06MqttApp/IotWebConf06MqttApp.ino
+++ b/examples/IotWebConf06MqttApp/IotWebConf06MqttApp.ino
@@ -152,7 +152,7 @@ void loop()
   }
 
   unsigned long now = millis();
-  if (((lastReport + 500) < now) && (pinState != digitalRead(CONFIG_PIN)))
+  if ((500 < now - lastReport) && (pinState != digitalRead(CONFIG_PIN)))
   {
     pinState = 1 - pinState; // invert pin state as it is changed
     lastReport = now;
@@ -213,7 +213,7 @@ boolean formValidator()
 
 boolean connectMqtt() {
   unsigned long now = millis();
-  if ((lastMqttConnectionAttempt + 1000) > now)
+  if (1000 > now - lastMqttConnectionAttempt)
   {
     // Do not repeat within 1 sec.
     return false;

--- a/examples/IotWebConf07MqttRelay/IotWebConf07MqttRelay.ino
+++ b/examples/IotWebConf07MqttRelay/IotWebConf07MqttRelay.ino
@@ -187,13 +187,13 @@ void loop()
 
   // -- Check for button push
   if ((digitalRead(BUTTON_PIN) == LOW)
-    && IotWebConf::smallerCheckOverflow(lastAction, ACTION_FEQ_LIMIT, now))
+    && ( ACTION_FEQ_LIMIT < now - lastAction))
   {
     needAction = 1 - state; // -- Invert the state
   }
   
   if ((needAction != NO_ACTION)
-    && IotWebConf::smallerCheckOverflow(lastAction, ACTION_FEQ_LIMIT, now))
+    && ( ACTION_FEQ_LIMIT < now - lastAction))
   {
     state = needAction;
     digitalWrite(RELAY_PIN, state);
@@ -267,7 +267,7 @@ boolean formValidator()
 
 boolean connectMqtt() {
   unsigned long now = millis();
-  if (!IotWebConf::smallerCheckOverflow(lastMqttConnectionAttempt, 1000, now))
+  if (1000 > now - lastMqttConnectionAttempt)
   {
     // Do not repeat within 1 sec.
     return false;

--- a/examples/IotWebConf08WebRelay/IotWebConf08WebRelay.ino
+++ b/examples/IotWebConf08WebRelay/IotWebConf08WebRelay.ino
@@ -118,7 +118,7 @@ void loop()
 
   // -- Check for button push
   if ((digitalRead(BUTTON_PIN) == LOW)
-    && IotWebConf::smallerCheckOverflow(lastAction, ACTION_FEQ_LIMIT, now))
+    && (ACTION_FEQ_LIMIT < now - lastAction))
   {
     needAction = 1 - state; // -- Invert the state
   }
@@ -129,7 +129,7 @@ void loop()
 void applyAction(unsigned long now)
 {
   if ((needAction != NO_ACTION)
-    && IotWebConf::smallerCheckOverflow(lastAction, ACTION_FEQ_LIMIT, now))
+    && (ACTION_FEQ_LIMIT < now - lastAction))
   {
     state = needAction;
     digitalWrite(RELAY_PIN, state);

--- a/src/IotWebConf.h
+++ b/src/IotWebConf.h
@@ -334,11 +334,6 @@ class IotWebConf
      */
     void configSave();
 
-    /**
-     * Helper method to check time elapse while checking number overflow.
-     * Will return true while the sum of the two numbers are smaller than the third one.
-     */
-    static boolean smallerCheckOverflow(unsigned long prevMillis, unsigned long diff, unsigned long currentMillis);
   private:
     const char* _initialApPassword = NULL;
     const char *_configVersion;


### PR DESCRIPTION
Remove smallerCheckOverflow function. Use duration check instead.
Duration comparison - checking timestamp differences - is rollover save.
Modify code to check
diff < curr - last
instead of
last + diff < curr
(which is not rollover safe).