### PR TITLE
Separator label

### DIFF
--- a/src/IotWebConf.cpp
+++ b/src/IotWebConf.cpp
@@ -387,6 +387,11 @@ void IotWebConf::handleConfig()
         Serial.println("Rendering separator");
 #endif
         page += "</fieldset><fieldset>";
+		if(current->label != NULL){
+            page += "<legend>";
+            page += current->label;
+            page += "</legend>";
+        }
       }
       else if (current->visible)
       {

--- a/src/IotWebConf.cpp
+++ b/src/IotWebConf.cpp
@@ -66,6 +66,10 @@ IotWebConfSeparator::IotWebConfSeparator()  : IotWebConfParameter(NULL, NULL, NU
 {
 }
 
+IotWebConfSeparator::IotWebConfSeparator(const char *label)  : IotWebConfParameter(label, NULL, NULL, 0, NULL, NULL, NULL, NULL, true)
+{
+}
+
 ////////////////////////////////////////////////////////////////
 
 IotWebConf::IotWebConf(const char* defaultThingName, DNSServer* dnsServer, WebServer* server,

--- a/src/IotWebConf.h
+++ b/src/IotWebConf.h
@@ -174,6 +174,10 @@ class IotWebConfSeparator : public IotWebConfParameter
 {
   public:
     IotWebConfSeparator();
+	/**
+	 * Create a seperator with a label (legend tag)
+	 */
+	IotWebConfSeparator(const char *label);
 };
 
 /**


### PR DESCRIPTION
This improvement allow the user to give a _legend_ to the _fieldset_ of a separator.
A new constructor IotWebConfSeparator(const char *label) is used to set the value of the legend.
![example](https://user-images.githubusercontent.com/25392287/53236854-9804f700-3695-11e9-887c-09583d98c343.png)

So we can customize custom parameters.