### PR TITLE
Added option to add legend to separator

### DIFF
--- a/examples/IotWebConf03CustomParameters/IotWebConf03CustomParameters.ino
+++ b/examples/IotWebConf03CustomParameters/IotWebConf03CustomParameters.ino
@@ -63,6 +63,8 @@ IotWebConf iotWebConf(thingName, &dnsServer, &server, wifiInitialApPassword, CON
 IotWebConfParameter stringParam = IotWebConfParameter("String param", "stringParam", stringParamValue, STRING_LEN);
 IotWebConfSeparator separator1 = IotWebConfSeparator();
 IotWebConfParameter intParam = IotWebConfParameter("Int param", "intParam", intParamValue, NUMBER_LEN, "number", "1..100", NULL, "min='1' max='100' step='1'");
+// -- We can add a legend to the separator
+IotWebConfSeparator separator2 = IotWebConfSeparator("Calibration factor");
 IotWebConfParameter floatParam = IotWebConfParameter("Float param", "floatParam", floatParamValue, NUMBER_LEN, "number", "e.g. 23.4", NULL, "step='0.1'");
 
 void setup() 
@@ -76,6 +78,7 @@ void setup()
   iotWebConf.addParameter(&stringParam);
   iotWebConf.addParameter(&separator1);
   iotWebConf.addParameter(&intParam);
+  iotWebConf.addParameter(&separator2);
   iotWebConf.addParameter(&floatParam);
   iotWebConf.setConfigSavedCallback(&configSaved);
   iotWebConf.setFormValidator(&formValidator);

--- a/src/IotWebConf.cpp
+++ b/src/IotWebConf.cpp
@@ -66,6 +66,10 @@ IotWebConfSeparator::IotWebConfSeparator()  : IotWebConfParameter(NULL, NULL, NU
 {
 }
 
+IotWebConfSeparator::IotWebConfSeparator(const char *label)  : IotWebConfParameter(label, NULL, NULL, 0, NULL, NULL, NULL, NULL, true)
+{
+}
+
 ////////////////////////////////////////////////////////////////
 
 IotWebConf::IotWebConf(const char* defaultThingName, DNSServer* dnsServer, WebServer* server,
@@ -387,6 +391,11 @@ void IotWebConf::handleConfig()
         Serial.println("Rendering separator");
 #endif
         page += "</fieldset><fieldset>";
+          if(current->label != NULL){
+            page += "<legend>";
+            page += current->label;
+            page += "</legend>";
+          }
       }
       else if (current->visible)
       {

--- a/src/IotWebConf.cpp
+++ b/src/IotWebConf.cpp
@@ -391,11 +391,12 @@ void IotWebConf::handleConfig()
         Serial.println("Rendering separator");
 #endif
         page += "</fieldset><fieldset>";
-          if(current->label != NULL){
-            page += "<legend>";
-            page += current->label;
-            page += "</legend>";
-          }
+        if (current->label != NULL)
+        {
+          page += "<legend>";
+          page += current->label;
+          page += "</legend>";
+        }
       }
       else if (current->visible)
       {

--- a/src/IotWebConf.h
+++ b/src/IotWebConf.h
@@ -174,6 +174,11 @@ class IotWebConfSeparator : public IotWebConfParameter
 {
   public:
     IotWebConfSeparator();
+
+    /**
+     * Create a seperator with a label (legend tag)
+     */
+    IotWebConfSeparator(const char *label);
 };
 
 /**


### PR DESCRIPTION
As requested, this is the new branch with the feature to add a legend to the separator.
The IotWebConf03CustomParameters example was also modified to show how to use.
![example](https://user-images.githubusercontent.com/25392287/53321684-71cf9900-38d9-11e9-89ba-7650eecbb062.png)
