### PR TITLE
Fix printing headEnd two times on the success page

### DIFF
--- a/src/IotWebConf.cpp
+++ b/src/IotWebConf.cpp
@@ -582,7 +582,7 @@ void IotWebConf::handleConfig()
     {
       page += F("Return to <a href='/'>home page</a>.");
     }
-    page += htmlFormatProvider->getHeadEnd();
+    page += htmlFormatProvider->getEnd();
 
     this->_server->sendHeader("Content-Length", String(page.length()));
     this->_server->send(200, "text/html; charset=UTF-8", page);


### PR DESCRIPTION
On the success page after saving the parameters, the `headEnd` is printed twice, this is usually not noticeable as most browsers understand and render the page right even with that, until someone (me) overrides the `getBodyInner` method to add an a image and we find a problem :P

Merry Christmas ;)