### PR TITLE
Make sure updateServer is initialized even if we skipAPStartup

### DIFF
--- a/src/IotWebConf.cpp
+++ b/src/IotWebConf.cpp
@@ -891,9 +891,9 @@ void IotWebConf::stateChanged(byte oldState, byte newState)
       {
         stopAp();
       }
-      if (oldState == IOTWEBCONF_STATE_BOOT && this->_updateServer != NULL)
+      if ((oldState == IOTWEBCONF_STATE_BOOT) && (this->_updateServer != NULL))
       {
-        // We skiped AP mode so update server was never setup yet
+        // We've skipped AP mode, so update server needs to be set up now.
         this->_updateServer->setup(this->_server, this->_updatePath);
       }
       this->blinkInternal(1000, 50);

--- a/src/IotWebConf.cpp
+++ b/src/IotWebConf.cpp
@@ -891,6 +891,11 @@ void IotWebConf::stateChanged(byte oldState, byte newState)
       {
         stopAp();
       }
+      if (oldState == IOTWEBCONF_STATE_BOOT && this->_updateServer != NULL)
+      {
+        // We skiped AP mode so update server was never setup yet
+        this->_updateServer->setup(this->_server, this->_updatePath);
+      }
       this->blinkInternal(1000, 50);
 #ifdef IOTWEBCONF_DEBUG_TO_SERIAL
       Serial.print("Connecting to [");


### PR DESCRIPTION
There is a bug: when skipAPSturtup() is used the updateServer is never initialized so when you browse the /firmware webpage it returns an error.

We need to make sure that the updateServer is initialized even if we skiped AP mode and also make sure the update server setup method is not executed more than once since it allocates memory on every call an so it causes a memory leak if we call it twice.

This is my solution.
Happy new year ;)