### PR TITLE
Add support for password fields longer than 33 chars. Closes #62

### DIFF
--- a/src/IotWebConf.cpp
+++ b/src/IotWebConf.cpp
@@ -81,7 +81,7 @@ IotWebConf::IotWebConf(
   this->_thingNameParameter = IotWebConfParameter("Thing name", "iwcThingName", this->_thingName, IOTWEBCONF_WORD_LEN);
   this->_apPasswordParameter = IotWebConfParameter("AP password", "iwcApPassword", this->_apPassword, IOTWEBCONF_WORD_LEN, "password");
   this->_wifiSsidParameter = IotWebConfParameter("WiFi SSID", "iwcWifiSsid", this->_wifiSsid, IOTWEBCONF_WORD_LEN);
-  this->_wifiPasswordParameter = IotWebConfParameter("WiFi password", "iwcWifiPassword", this->_wifiPassword, IOTWEBCONF_WORD_LEN, "password");
+  this->_wifiPasswordParameter = IotWebConfParameter("WiFi password", "iwcWifiPassword", this->_wifiPassword, IOTWEBCONF_WIFI_PASSWORD_LEN, "password");
   this->_apTimeoutParameter = IotWebConfParameter("Startup delay (seconds)", "iwcApTimeout", this->_apTimeoutStr, IOTWEBCONF_WORD_LEN, "number", NULL, NULL, "min='1' max='600'", false);
   this->addParameter(&this->_thingNameParameter);
   this->addParameter(&this->_apPasswordParameter);
@@ -499,17 +499,15 @@ void IotWebConf::handleConfig()
   {
     // -- Save config
     IOTWEBCONF_DEBUG_LINE(F("Updating configuration"));
-    char temp[IOTWEBCONF_WORD_LEN];
 
     IotWebConfParameter* current = this->_firstParameter;
     while (current != NULL)
     {
       if ((current->getId() != NULL) && (current->visible))
       {
-        if ((strcmp("password", current->type) == 0) &&
-            (current->getLength() <= IOTWEBCONF_WORD_LEN))
+        if (strcmp("password", current->type) == 0)
         {
-          // TODO: Passwords longer than IOTWEBCONF_WORD_LEN not supported.
+          char temp[current->getLength() + 1];
           this->readParamValue(current->getId(), temp, current->getLength());
           if (temp[0] != '\0')
           {
@@ -535,18 +533,7 @@ void IotWebConf::handleConfig()
 #ifdef IOTWEBCONF_DEBUG_TO_SERIAL
           Serial.print(current->getId());
           Serial.print("='");
-# ifdef IOTWEBCONF_DEBUG_PWD_TO_SERIAL
           Serial.print(current->valueBuffer);
-# else
-          if (strcmp("password", current->type) == 0)
-          {
-            Serial.print(F("<hidden>"));
-          }
-          else
-          {
-            Serial.print(current->valueBuffer);
-          }
-# endif
           Serial.println("'");
 #endif
         }

--- a/src/IotWebConf.cpp
+++ b/src/IotWebConf.cpp
@@ -507,7 +507,7 @@ void IotWebConf::handleConfig()
       {
         if (strcmp("password", current->type) == 0)
         {
-          char temp[current->getLength() + 1];
+          char temp[current->getLength()];
           this->readParamValue(current->getId(), temp, current->getLength());
           if (temp[0] != '\0')
           {

--- a/src/IotWebConf.h
+++ b/src/IotWebConf.h
@@ -31,6 +31,9 @@
 // ssid, password).
 #define IOTWEBCONF_WORD_LEN 33
 
+// -- Maximal length of string used as WiFi password in IotWebConfig
+#define IOTWEBCONF_WIFI_PASSWORD_LEN 65
+
 // -- IotWebConf tries to connect to the local network for an amount of time
 // before falling back to AP mode.
 #define IOTWEBCONF_DEFAULT_WIFI_CONNECTION_TIMEOUT_MS 30000
@@ -119,8 +122,7 @@ public:
    *   @length - The buffer should have a length provided here.
    *   @type (optional, default="text") - The type of the html input field.
    *       The type="password" has a special handling, as the value will be overwritten in the EEPROM
-   *       only if value was provided on the config portal. Because of this logic, "password" type field with
-   *       length more then IOTWEBCONF_WORD_LEN characters are not supported.
+   *       only if value was provided on the config portal.
    *   @placeholder (optional) - Text appear in an empty input box.
    *   @defaultValue (optional) - Value should be pre-filled if none was specified before.
    *   @customHtml (optional) - The text of this parameter will be added into the HTML INPUT field.
@@ -494,7 +496,7 @@ private:
   char _thingName[IOTWEBCONF_WORD_LEN];
   char _apPassword[IOTWEBCONF_WORD_LEN];
   char _wifiSsid[IOTWEBCONF_WORD_LEN];
-  char _wifiPassword[IOTWEBCONF_WORD_LEN];
+  char _wifiPassword[IOTWEBCONF_WIFI_PASSWORD_LEN];
   char _apTimeoutStr[IOTWEBCONF_WORD_LEN];
   unsigned long _apTimeoutMs = IOTWEBCONF_DEFAULT_AP_MODE_TIMEOUT_MS;
   unsigned long _wifiConnectionTimeoutMs =


### PR DESCRIPTION
This is my suggestion for supporting password fields longer than IOTWEBCONF_WORD_LEN using a dynamic temp buffer on the stack.

I think it's a good approach since password fields should never be so long to fill the stack, but if you think that could be a problem I can change it to allocate the buffer on the heap.