### PR TITLE
Fix parameters being truncated due to wrong length limit

### DIFF
--- a/src/IotWebConf.cpp
+++ b/src/IotWebConf.cpp
@@ -438,7 +438,7 @@ void IotWebConf::handleConfig()
           pitem.replace("{t}", current->type);
           pitem.replace("{i}", current->getId());
           pitem.replace("{p}", current->placeholder == NULL ? "" : current->placeholder);
-          snprintf(parLength, 5, "%d", current->getLength());
+          snprintf(parLength, 5, "%d", current->getLength()-1);
           pitem.replace("{l}", parLength);
           if (strcmp("password", current->type) == 0)
           {


### PR DESCRIPTION
There is a bug that causes the parameters to be truncated after they are saved. This is because the max length set in the parameter settings is the size of the buffer, but in the HTML the max length does not count for the null termination character.

Let's take the Thing_name as an example. The max length is set to IOTWEBCONF_WORD_LEN (33) so the HTML form let you write up to 33 characters. When we try to save the string into the _thingName attribute it is truncated since we can only store 32 characters plus the null terminator.

A think this is the proper way of fixing this as the IotWebConfParameter states that the length provided is the length of the buffer, not length of the string. Also it is the safest way to handle it.