### PR TITLE
Fix crashing when error message not set yet

### DIFF
--- a/src/IotWebConf.cpp
+++ b/src/IotWebConf.cpp
@@ -40,6 +40,7 @@ IotWebConfParameter::IotWebConfParameter(
   this->defaultValue = defaultValue;
   this->customHtml = customHtml;
   this->visible = visible;
+  this->errorMessage = NULL;
 }
 IotWebConfParameter::IotWebConfParameter(
     const char* id, char* valueBuffer, int length, const char* customHtml,


### PR DESCRIPTION
ESP32 has been crashing due to wstring trying to print the error message before it's initialized, should be set to NULL in the constructor. 