### PR TITLE
Introducing more control for blinking

### DIFF
--- a/src/IotWebConf.cpp
+++ b/src/IotWebConf.cpp
@@ -21,7 +21,7 @@
 # endif
 #endif
 
-#define IOTWEBCONF_STATUS_ENABLED (this->_statusPin >= 0)
+#define IOTWEBCONF_STATUS_ENABLED (this->_statusPin >= 0 and this->_blinkEnabled)
 
 IotWebConfParameter::IotWebConfParameter()
 {
@@ -1094,6 +1094,17 @@ void IotWebConf::blinkInternal(unsigned long repeatMs, byte dutyCyclePercent)
   this->blink(repeatMs, dutyCyclePercent);
   this->_internalBlinkOnMs = this->_blinkOnMs;
   this->_internalBlinkOffMs = this->_blinkOffMs;
+}
+
+void IotWebConf::disableBlinkRoutine(){
+  this->_blinkEnabled = false;
+}
+
+void IotWebConf::enableBlinkRoutine(){
+  this->_blinkEnabled = true;
+}
+bool IotWebConf::isBlinkEnabled(){
+  return IOTWEBCONF_STATUS_ENABLED;
 }
 
 void IotWebConf::doBlink()

--- a/src/IotWebConf.cpp
+++ b/src/IotWebConf.cpp
@@ -106,6 +106,11 @@ void IotWebConf::setStatusPin(int statusPin)
   this->_statusPin = statusPin;
 }
 
+void IotWebConf::setStatusOn(int statusOn)
+{
+  this->_STATUS_ON = statusOn;
+}
+
 void IotWebConf::setupUpdateServer(
     HTTPUpdateServer* updateServer, const char* updatePath)
 {
@@ -1097,7 +1102,7 @@ void IotWebConf::doBlink()
   {
     unsigned long now = millis();
     unsigned long delayMs =
-        this->_blinkState == LOW ? this->_blinkOnMs : this->_blinkOffMs;
+        this->_blinkState == this->_STATUS_ON ? this->_blinkOnMs : this->_blinkOffMs;
     if (delayMs < now - this->_lastBlinkTime)
     {
       this->_blinkState = 1 - this->_blinkState;

--- a/src/IotWebConf.h
+++ b/src/IotWebConf.h
@@ -106,7 +106,7 @@ const char IOTWEBCONF_HTML_CONFIG_VER[] PROGMEM   = "<div style='font-size: .6em
 
 // -- Status indicator output logical levels.
 #define IOTWEBCONF_STATUS_ON LOW
-#define IOTWEBCONF_STATUS_OFF HIGH
+// #define IOTWEBCONF_STATUS_OFF HIGH // Not used
 
 // -- User name on login.
 #define IOTWEBCONF_ADMIN_USER_NAME "admin"
@@ -257,6 +257,13 @@ public:
    *   @statusPin - An Arduino pin. Will be configured as OUTPUT!
    */
   void setStatusPin(int statusPin);
+
+  /**
+   * Allows to set different value for an On state of the status indicator. Default is LOW (see IOTWEBCONF_STATUS_ON)
+   * Must be called before init()!
+   *   @statusOn - LOW or HIGH
+   */
+  void setStatusOn(int statusOn);
 
   /**
    * Add an UpdateServer instance to the system. The firmware update link will appear on the config portal.
@@ -506,6 +513,7 @@ private:
   HTTPUpdateServer* _updateServer = NULL;
   int _configPin = -1;
   int _statusPin = -1;
+  int _STATUS_ON = IOTWEBCONF_STATUS_ON;
   const char* _updatePath = NULL;
   boolean _forceDefaultPassword = false;
   boolean _skipApStartup = false;

--- a/src/IotWebConf.h
+++ b/src/IotWebConf.h
@@ -412,6 +412,21 @@ public:
   void stopCustomBlink();
 
   /**
+   * Disables blinking and allows to control same LED with other code.
+   */
+  void disableBlinkRoutine();
+
+  /**
+   * Enables blinking again after it has been disabled by disableBlinkRoutine
+   */
+  void enableBlinkRoutine();
+
+  /**
+   * Returns true if blinking will be processed by library (blinking enabled and configured)
+   */
+  bool isBlinkEnabled();
+
+  /**
    * Return the current state, that will be a value from the IOTWEBCONF_STATE_* constants.
    */
   byte getState() { return this->_state; };
@@ -549,6 +564,7 @@ private:
   unsigned long _blinkOnMs = 500;
   unsigned long _blinkOffMs = 500;
   byte _blinkState = IOTWEBCONF_STATUS_ON;
+  boolean _blinkEnabled = true;
   unsigned long _lastBlinkTime = 0;
   unsigned long _wifiConnectionStart = 0;
   IotWebConfWifiAuthInfo _wifiAuthInfo = {_wifiSsid, _wifiPassword};


### PR DESCRIPTION
New methods:

- `void setStatusOn(int statusOn)` - allows to set what level (high/low) corresponds to the "on" state of LED.
- `void disableBlinkRoutine()` - allows temporary disable blinker like it's configured; this is need if you want to control LED with other code
- `void enableBlinkRoutine()` - enables previously  disabled blinker
- `bool isBlinkEnabled()` - returns current state