### PR TITLE
Change to sending handleConfig() in chunks to reduce memory usage

### DIFF
--- a/src/IotWebConf.cpp
+++ b/src/IotWebConf.cpp
@@ -420,6 +420,7 @@ void IotWebConf::handleConfig()
           page_separator += "<legend>";
           page_separator += current->label;
           page_separator += "</legend>";
+          this->_server->sendContent(page_separator);            
         }
       }
       else if (current->visible)


### PR DESCRIPTION
Many apologies as this is my first use of Github, so may have got this totally wrong.

I ran out of memory when working on a project with lots of IotWebConf parameters, and this was my solution.

Instead of storing the entire handleConfig() response in one String and sending when complete, this pull sends the header, then each parameter, then the footer as a chunked output. It works on ESP8266, but don't have an ESP32 to test with.