### PR TITLE
Add option to use ESPAsyncWebServer

### DIFF
--- a/examples/Async_IotWebConf01Minimal/Async_IotWebConf01Minimal.ino
+++ b/examples/Async_IotWebConf01Minimal/Async_IotWebConf01Minimal.ino
@@ -1,0 +1,95 @@
+/**
+ * IotWebConf01Minimal.ino -- IotWebConf is an ESP8266/ESP32
+ *   non blocking WiFi/AP web configuration library for Arduino.
+ *   https://github.com/prampec/IotWebConf 
+ *
+ * Copyright (C) 2018 Balazs Kelemen <prampec+arduino@gmail.com>
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+/**
+ * Example: Minimal
+ * Description:
+ *   This example will shows the bare minimum required for IotWebConf to start up.
+ *   After starting up the thing, please search for WiFi access points e.g. with
+ *   your phone. Use password provided in the code!
+ *   After connecting to the access point the root page will automatically appears.
+ *   We call this "captive portal".
+ *   
+ *   Please set a new password for the Thing (for the access point) as well as
+ *   the SSID and password of your local WiFi. You cannot move on without these steps.
+ *   
+ *   You have to leave the access point before to let the Thing continue operation
+ *   with connecting to configured WiFi.
+ *
+ *   Note that you can find detailed debug information in the serial console depending
+ *   on the settings IOTWEBCONF_DEBUG_TO_SERIAL, IOTWEBCONF_DEBUG_PWD_TO_SERIAL set
+ *   in the IotWebConf.h .
+ */
+ 
+/**
+ * Important: This example requires ESPAsyncWebServer library, https://github.com/me-no-dev/ESPAsyncWebServer
+ * Also for ESP8266 it requires ESPAsyncTCP, https://github.com/me-no-dev/ESPAsyncTCP
+ * For ESP32 it requires AsyncTCP, https://github.com/me-no-dev/AsyncTCP
+ * 
+ * To enable the use of the AsyncWebServer #define IOTWEBCONF_CONFIG_USE_ASYNC must be
+ * uncommented in IotWebConf.h, or otherwise defined.
+ */
+
+#include <IotWebConf.h>
+
+// -- Initial name of the Thing. Used e.g. as SSID of the own Access Point.
+const char thingName[] = "testThing";
+
+// -- Initial password to connect to the Thing, when it creates an own Access Point.
+const char wifiInitialApPassword[] = "smrtTHNG8266";
+
+DNSServer dnsServer;
+AsyncWebServer server(80);
+
+IotWebConf iotWebConf(thingName, &dnsServer, &server, wifiInitialApPassword);
+
+void setup() 
+{
+  Serial.begin(115200);
+  Serial.println();
+  Serial.println("Starting up...");
+
+  // -- Initializing the configuration.
+  iotWebConf.init();
+
+  // -- Set up required URL handlers on the web server.
+  server.on("/", handleRoot);
+  server.on("/config", [](AsyncWebServerRequest *request){ iotWebConf.handleConfig(request); });
+  server.onNotFound([](AsyncWebServerRequest *request){ iotWebConf.handleNotFound(request); });
+
+  Serial.println("Ready.");
+}
+
+void loop() 
+{
+  // -- doLoop should be called as frequently as possible.
+  iotWebConf.doLoop();
+}
+
+/**
+ * Handle web requests to "/" path.
+ */
+void handleRoot(AsyncWebServerRequest *request)
+{
+  // -- Let IotWebConf test and handle captive portal requests.
+  if (iotWebConf.handleCaptivePortal(request))
+  {
+    // -- Captive portal request were already served.
+    return;
+  }
+  String s = "<!DOCTYPE html><html lang=\"en\"><head><meta name=\"viewport\" content=\"width=device-width, initial-scale=1, user-scalable=no\"/>";
+  s += "<title>IotWebConf 01 Minimal</title></head><body>Hello world!";
+  s += "Go to <a href='config'>configure page</a> to change settings.";
+  s += "</body></html>\n";
+
+  request->send(200, "text/html", s);
+}
+

--- a/examples/Async_IotWebConf02StatusAndReset/Async_IotWebConf02StatusAndReset.ino
+++ b/examples/Async_IotWebConf02StatusAndReset/Async_IotWebConf02StatusAndReset.ino
@@ -1,0 +1,105 @@
+/**
+ * IotWebConf02StatusAndReset.ino -- IotWebConf is an ESP8266/ESP32
+ *   non blocking WiFi/AP web configuration library for Arduino.
+ *   https://github.com/prampec/IotWebConf 
+ *
+ * Copyright (C) 2018 Balazs Kelemen <prampec+arduino@gmail.com>
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+/**
+ * Example: Status and Reset
+ * Description:
+ *   This example is very similar to the "minimal" example.
+ *   But here we provide a status indicator LED, to get feedback
+ *   of the thing state.
+ *   Further more we set up a push button. If push button is detected
+ *   to be pressed at boot time, the thing will use the initial
+ *   password for accepting connections in Access Point mode. This
+ *   is usefull e.g. when custom password was lost.
+ *   (See previous examples for more details!)
+ * 
+ * Hardware setup for this example:
+ *   - An LED is attached to LED_BUILTIN pin with setup On=LOW.
+ *     This is hopefully already attached by default.
+ *   - A push button is attached to pin D2, the other leg of the
+ *     button should be attached to GND.
+ */
+
+/**
+ * Important: This example requires ESPAsyncWebServer library, https://github.com/me-no-dev/ESPAsyncWebServer
+ * Also for ESP8266 it requires ESPAsyncTCP, https://github.com/me-no-dev/ESPAsyncTCP
+ * For ESP32 it requires AsyncTCP, https://github.com/me-no-dev/AsyncTCP
+ * 
+ * To enable the use of the AsyncWebServer #define IOTWEBCONF_CONFIG_USE_ASYNC must be
+ * uncommented in IotWebConf.h, or otherwise defined.
+ */
+ 
+#include <IotWebConf.h>
+
+// -- Initial name of the Thing. Used e.g. as SSID of the own Access Point.
+const char thingName[] = "testThing";
+
+// -- Initial password to connect to the Thing, when it creates an own Access Point.
+const char wifiInitialApPassword[] = "smrtTHNG8266";
+
+// -- When CONFIG_PIN is pulled to ground on startup, the Thing will use the initial
+//      password to build an AP. (E.g. in case of lost password)
+#define CONFIG_PIN D2
+
+// -- Status indicator pin.
+//      First it will light up (kept LOW), on Wifi connection it will blink,
+//      when connected to the Wifi it will turn off (kept HIGH).
+#define STATUS_PIN LED_BUILTIN
+
+DNSServer dnsServer;
+AsyncWebServer server(80);
+
+IotWebConf iotWebConf(thingName, &dnsServer, &server, wifiInitialApPassword);
+
+void setup() 
+{
+  Serial.begin(115200);
+  Serial.println();
+  Serial.println("Starting up...");
+
+  // -- Initializing the configuration.
+  iotWebConf.setStatusPin(STATUS_PIN);
+  iotWebConf.setConfigPin(CONFIG_PIN);
+  iotWebConf.init();
+
+  // -- Set up required URL handlers on the web server.
+  server.on("/", handleRoot);
+  server.on("/config", [](AsyncWebServerRequest *request){ iotWebConf.handleConfig(request); });
+  server.onNotFound([](AsyncWebServerRequest *request){ iotWebConf.handleNotFound(request); });
+
+  Serial.println("Ready.");
+}
+
+void loop() 
+{
+  // -- doLoop should be called as frequently as possible.
+  iotWebConf.doLoop();
+}
+
+/**
+ * Handle web requests to "/" path.
+ */
+void handleRoot(AsyncWebServerRequest *request)
+{
+  // -- Let IotWebConf test and handle captive portal requests.
+  if (iotWebConf.handleCaptivePortal(request))
+  {
+    // -- Captive portal request were already served.
+    return;
+  }
+  String s = "<!DOCTYPE html><html lang=\"en\"><head><meta name=\"viewport\" content=\"width=device-width, initial-scale=1, user-scalable=no\"/>";
+  s += "<title>IotWebConf 02 Status and Reset</title></head><body>Hello world!";
+  s += "Go to <a href='config'>configure page</a> to change settings.";
+  s += "</body></html>\n";
+
+  request->send(200, "text/html", s);
+}
+

--- a/examples/Async_IotWebConf04UpdateServer/Async_IotWebConf04UpdateServer.ino
+++ b/examples/Async_IotWebConf04UpdateServer/Async_IotWebConf04UpdateServer.ino
@@ -1,0 +1,108 @@
+/**
+ * IotWebConf04UpdateServer.ino -- IotWebConf is an ESP8266/ESP32
+ *   non blocking WiFi/AP web configuration library for Arduino.
+ *   https://github.com/prampec/IotWebConf 
+ *
+ * Copyright (C) 2018 Balazs Kelemen <prampec+arduino@gmail.com>
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+/**
+ * Example: Update Server
+ * Description:
+ *   In this example we will provide a "firmware update" link in the
+ *   config portal.
+ *   (See ESP8266 ESP8266HTTPUpdateServer examples 
+ *   to understand UpdateServer!)
+ *   (ESP32: HTTPUpdateServer library is ported for ESP32 in this project.)
+ *   (See previous examples for more details!)
+ * 
+ * Hardware setup for this example:
+ *   - An LED is attached to LED_BUILTIN pin with setup On=LOW.
+ *   - [Optional] A push button is attached to pin D2, the other leg of the
+ *     button should be attached to GND.
+ */
+
+/**
+ * Important: This example requires ESPAsyncWebServer library, https://github.com/me-no-dev/ESPAsyncWebServer
+ * Also for ESP8266 it requires ESPAsyncTCP, https://github.com/me-no-dev/ESPAsyncTCP
+ * For ESP32 it requires AsyncTCP, https://github.com/me-no-dev/AsyncTCP
+ * 
+ * To enable the use of the AsyncWebServer #define IOTWEBCONF_CONFIG_USE_ASYNC must be
+ * uncommented in IotWebConf.h, or otherwise defined.
+ */
+ 
+#include <IotWebConf.h>
+
+// -- Initial name of the Thing. Used e.g. as SSID of the own Access Point.
+const char thingName[] = "testThing";
+
+// -- Initial password to connect to the Thing, when it creates an own Access Point.
+const char wifiInitialApPassword[] = "smrtTHNG8266";
+
+// -- Configuration specific key. The value should be modified if config structure was changed.
+#define CONFIG_VERSION "dem1"
+
+// -- When CONFIG_PIN is pulled to ground on startup, the Thing will use the initial
+//      password to buld an AP. (E.g. in case of lost password)
+#define CONFIG_PIN D2
+
+// -- Status indicator pin.
+//      First it will light up (kept LOW), on Wifi connection it will blink,
+//      when connected to the Wifi it will turn off (kept HIGH).
+#define STATUS_PIN LED_BUILTIN
+
+DNSServer dnsServer;
+AsyncWebServer server(80);
+HTTPUpdateServer httpUpdater;
+
+IotWebConf iotWebConf(thingName, &dnsServer, &server, wifiInitialApPassword, CONFIG_VERSION);
+
+void setup() 
+{
+  Serial.begin(115200);
+  Serial.println();
+  Serial.println("Starting up...");
+
+  iotWebConf.setStatusPin(STATUS_PIN);
+  iotWebConf.setConfigPin(CONFIG_PIN);
+  iotWebConf.setupUpdateServer(&httpUpdater);
+
+  // -- Initializing the configuration.
+  iotWebConf.init();
+
+  // -- Set up required URL handlers on the web server.
+  server.on("/", handleRoot);
+  server.on("/config", [](AsyncWebServerRequest *request){ iotWebConf.handleConfig(request); });
+  server.onNotFound([](AsyncWebServerRequest *request){ iotWebConf.handleNotFound(request); });
+
+  Serial.println("Ready.");
+}
+
+void loop() 
+{
+  // -- doLoop should be called as frequently as possible.
+  iotWebConf.doLoop();
+}
+
+/**
+ * Handle web requests to "/" path.
+ */
+void handleRoot(AsyncWebServerRequest *request)
+{
+  // -- Let IotWebConf test and handle captive portal requests.
+  if (iotWebConf.handleCaptivePortal(request))
+  {
+    // -- Captive portal request were already served.
+    return;
+  }
+  String s = "<!DOCTYPE html><html lang=\"en\"><head><meta name=\"viewport\" content=\"width=device-width, initial-scale=1, user-scalable=no\"/>";
+  s += "<title>IotWebConf 04 Update Server</title></head><body>Hello world!";
+  s += "Go to <a href='config'>configure page</a> to change values.";
+  s += "</body></html>\n";
+
+  request->send(200, "text/html", s);
+}
+

--- a/examples/Async_IotWebConf06MqttApp/Async_IotWebConf06MqttApp.ino
+++ b/examples/Async_IotWebConf06MqttApp/Async_IotWebConf06MqttApp.ino
@@ -1,0 +1,274 @@
+/**
+ * IotWebConf06MqttApp.ino -- IotWebConf is an ESP8266/ESP32
+ *   non blocking WiFi/AP web configuration library for Arduino.
+ *   https://github.com/prampec/IotWebConf 
+ *
+ * Copyright (C) 2018 Balazs Kelemen <prampec+arduino@gmail.com>
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+/**
+ * Example: MQTT Demo Application
+ * Description:
+ *   All IotWebConf specific aspects of this example are described in
+ *   previous examples, so please get familiar with IotWebConf before
+ *   starting this example. So nothing new will be explained here, 
+ *   but a complete demo application will be build.
+ *   It is also expected from the reader to have a basic knowledge over
+ *   MQTT to understand this code.
+ *   
+ *   This example starts an MQTT client with the configured
+ *   connection settings.
+ *   Will post the status changes of the D2 pin in channel "/test/status".
+ *   Receives messages appears in channel "/test/action", and writes them to serial.
+ *   This example also provides the firmware update option.
+ *   (See previous examples for more details!)
+ * 
+ * Software setup for this example:
+ *   This example utilizes Joel Gaehwiler's MQTT library.
+ *   https://github.com/256dpi/arduino-mqtt
+ * 
+ * Hardware setup for this example:
+ *   - An LED is attached to LED_BUILTIN pin with setup On=LOW.
+ *   - [Optional] A push button is attached to pin D2, the other leg of the
+ *     button should be attached to GND.
+ */
+ 
+ /**
+ * Important: This example requires ESPAsyncWebServer library, https://github.com/me-no-dev/ESPAsyncWebServer
+ * Also for ESP8266 it requires ESPAsyncTCP, https://github.com/me-no-dev/ESPAsyncTCP
+ * For ESP32 it requires AsyncTCP, https://github.com/me-no-dev/AsyncTCP
+ * 
+ * To enable the use of the AsyncWebServer #define IOTWEBCONF_CONFIG_USE_ASYNC must be
+ * uncommented in IotWebConf.h, or otherwise defined.
+ */
+
+#include <MQTT.h>
+#include <IotWebConf.h>
+
+// -- Initial name of the Thing. Used e.g. as SSID of the own Access Point.
+const char thingName[] = "testThing";
+
+// -- Initial password to connect to the Thing, when it creates an own Access Point.
+const char wifiInitialApPassword[] = "smrtTHNG8266";
+
+#define STRING_LEN 128
+
+// -- Configuration specific key. The value should be modified if config structure was changed.
+#define CONFIG_VERSION "mqt1"
+
+// -- When CONFIG_PIN is pulled to ground on startup, the Thing will use the initial
+//      password to buld an AP. (E.g. in case of lost password)
+#define CONFIG_PIN D2
+
+// -- Status indicator pin.
+//      First it will light up (kept LOW), on Wifi connection it will blink,
+//      when connected to the Wifi it will turn off (kept HIGH).
+#define STATUS_PIN LED_BUILTIN
+
+// -- Callback method declarations.
+void wifiConnected();
+void configSaved();
+boolean formValidator(AsyncWebServerRequest *request);
+void mqttMessageReceived(String &topic, String &payload);
+
+DNSServer dnsServer;
+AsyncWebServer server(80);
+HTTPUpdateServer httpUpdater;
+WiFiClient net;
+MQTTClient mqttClient;
+
+char mqttServerValue[STRING_LEN];
+char mqttUserNameValue[STRING_LEN];
+char mqttUserPasswordValue[STRING_LEN];
+
+IotWebConf iotWebConf(thingName, &dnsServer, &server, wifiInitialApPassword, CONFIG_VERSION);
+IotWebConfParameter mqttServerParam = IotWebConfParameter("MQTT server", "mqttServer", mqttServerValue, STRING_LEN);
+IotWebConfParameter mqttUserNameParam = IotWebConfParameter("MQTT user", "mqttUser", mqttUserNameValue, STRING_LEN);
+IotWebConfParameter mqttUserPasswordParam = IotWebConfParameter("MQTT password", "mqttPass", mqttUserPasswordValue, STRING_LEN, "password");
+
+boolean needMqttConnect = false;
+boolean needReset = false;
+int pinState = HIGH;
+unsigned long lastReport = 0;
+unsigned long lastMqttConnectionAttempt = 0;
+
+void setup() 
+{
+  Serial.begin(115200);
+  Serial.println();
+  Serial.println("Starting up...");
+
+  iotWebConf.setStatusPin(STATUS_PIN);
+  iotWebConf.setConfigPin(CONFIG_PIN);
+  iotWebConf.addParameter(&mqttServerParam);
+  iotWebConf.addParameter(&mqttUserNameParam);
+  iotWebConf.addParameter(&mqttUserPasswordParam);
+  iotWebConf.setConfigSavedCallback(&configSaved);
+  iotWebConf.setFormValidator(&formValidator);
+  iotWebConf.setWifiConnectionCallback(&wifiConnected);
+  iotWebConf.setupUpdateServer(&httpUpdater);
+
+  // -- Initializing the configuration.
+  boolean validConfig = iotWebConf.init();
+  if (!validConfig)
+  {
+    mqttServerValue[0] = '\0';
+    mqttUserNameValue[0] = '\0';
+    mqttUserPasswordValue[0] = '\0';
+  }
+
+  // -- Set up required URL handlers on the web server.
+  server.on("/", handleRoot);
+  server.on("/config", [](AsyncWebServerRequest *request){ iotWebConf.handleConfig(request); });
+  server.onNotFound([](AsyncWebServerRequest *request){ iotWebConf.handleNotFound(request); });
+
+  mqttClient.begin(mqttServerValue, net);
+  mqttClient.onMessage(mqttMessageReceived);
+  
+  Serial.println("Ready.");
+}
+
+void loop() 
+{
+  // -- doLoop should be called as frequently as possible.
+  iotWebConf.doLoop();
+  mqttClient.loop();
+  
+  if (needMqttConnect)
+  {
+    if (connectMqtt())
+    {
+      needMqttConnect = false;
+    }
+  }
+  else if ((iotWebConf.getState() == IOTWEBCONF_STATE_ONLINE) && (!mqttClient.connected()))
+  {
+    Serial.println("MQTT reconnect");
+    connectMqtt();
+  }
+
+  if (needReset)
+  {
+    Serial.println("Rebooting after 1 second.");
+    iotWebConf.delay(1000);
+    ESP.restart();
+  }
+
+  unsigned long now = millis();
+  if ((500 < now - lastReport) && (pinState != digitalRead(CONFIG_PIN)))
+  {
+    pinState = 1 - pinState; // invert pin state as it is changed
+    lastReport = now;
+    Serial.print("Sending on MQTT channel '/test/status' :");
+    Serial.println(pinState == LOW ? "ON" : "OFF");
+    mqttClient.publish("/test/status", pinState == LOW ? "ON" : "OFF");
+  }
+}
+
+/**
+ * Handle web requests to "/" path.
+ */
+void handleRoot(AsyncWebServerRequest *request)
+{
+  // -- Let IotWebConf test and handle captive portal requests.
+  if (iotWebConf.handleCaptivePortal(request))
+  {
+    // -- Captive portal request were already served.
+    return;
+  }
+  String s = "<!DOCTYPE html><html lang=\"en\"><head><meta name=\"viewport\" content=\"width=device-width, initial-scale=1, user-scalable=no\"/>";
+  s += "<title>IotWebConf 06 MQTT App</title></head><body>MQTT App demo";
+  s += "<ul>";
+  s += "<li>MQTT server: ";
+  s += mqttServerValue;
+  s += "</ul>";
+  s += "Go to <a href='config'>configure page</a> to change values.";
+  s += "</body></html>\n";
+
+  request->send(200, "text/html", s);
+}
+
+void wifiConnected()
+{
+  needMqttConnect = true;
+}
+
+void configSaved()
+{
+  Serial.println("Configuration was updated.");
+  needReset = true;
+}
+
+boolean formValidator(AsyncWebServerRequest *request)
+{
+  Serial.println("Validating form.");
+  boolean valid = true;
+
+  int l = request->arg(mqttServerParam.getId()).length();
+  if (l < 3)
+  {
+    mqttServerParam.errorMessage = "Please provide at least 3 characters!";
+    valid = false;
+  }
+
+  return valid;
+}
+
+boolean connectMqtt() {
+  unsigned long now = millis();
+  if (1000 > now - lastMqttConnectionAttempt)
+  {
+    // Do not repeat within 1 sec.
+    return false;
+  }
+  Serial.println("Connecting to MQTT server...");
+  if (!connectMqttOptions()) {
+    lastMqttConnectionAttempt = now;
+    return false;
+  }
+  Serial.println("Connected!");
+
+  mqttClient.subscribe("/test/action");
+  return true;
+}
+
+/*
+// -- This is an alternative MQTT connection method.
+boolean connectMqtt() {
+  Serial.println("Connecting to MQTT server...");
+  while (!connectMqttOptions()) {
+    iotWebConf.delay(1000);
+  }
+  Serial.println("Connected!");
+
+  mqttClient.subscribe("/test/action");
+  return true;
+}
+*/
+
+boolean connectMqttOptions()
+{
+  boolean result;
+  if (mqttUserPasswordValue[0] != '\0')
+  {
+    result = mqttClient.connect(iotWebConf.getThingName(), mqttUserNameValue, mqttUserPasswordValue);
+  }
+  else if (mqttUserNameValue[0] != '\0')
+  {
+    result = mqttClient.connect(iotWebConf.getThingName(), mqttUserNameValue);
+  }
+  else
+  {
+    result = mqttClient.connect(iotWebConf.getThingName());
+  }
+  return result;
+}
+
+void mqttMessageReceived(String &topic, String &payload)
+{
+  Serial.println("Incoming: " + topic + " - " + payload);
+}
+

--- a/examples/Async_IotWebConf07MqttRelay/Async_IotWebConf07MqttRelay.ino
+++ b/examples/Async_IotWebConf07MqttRelay/Async_IotWebConf07MqttRelay.ino
@@ -1,0 +1,309 @@
+/**
+ * IotWebConf07MqttRelay.ino -- IotWebConf is an ESP8266/ESP32
+ *   non blocking WiFi/AP web configuration library for Arduino.
+ *   https://github.com/prampec/IotWebConf 
+ *
+ * Copyright (C) 2018 Balazs Kelemen <prampec+arduino@gmail.com>
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+/**
+ * Example: MQTT Relay Demo
+ * Description:
+ *   All IotWebConf specific aspects of this example are described in
+ *   previous examples, so please get familiar with IotWebConf before
+ *   starting this example. So nothing new will be explained here, 
+ *   but a complete demo application will be built.
+ *   It is also expected from the reader to have a basic knowledge over
+ *   MQTT to understand this code.
+ *   
+ *   This example starts an MQTT client with the configured
+ *   connection settings.
+ *   Will receives messages appears in channel "/devices/[thingName]/action"
+ *   with payload ON/OFF, and reports current state in channel
+ *   "/devices/[thingName]/status" (ON/OFF). Where the thingName can be
+ *   configured in the portal. A relay will be switched on/off
+ *   corresponding to the received action. The relay can be also controlled
+ *   by the push button.
+ *   The thing will delay actions arriving within 7 seconds.
+ *   
+ *   This example also provides the firmware update option.
+ *   (See previous examples for more details!)
+ * 
+ * Software setup for this example:
+ *   This example utilizes Joel Gaehwiler's MQTT library.
+ *   https://github.com/256dpi/arduino-mqtt
+ * 
+ * Hardware setup for this example:
+ *   - A Relay is attached to the D5 pin (On=HIGH). Note on relay pin!
+ *   - An LED is attached to LED_BUILTIN pin with setup On=LOW.
+ *   - A push button is attached to pin D2, the other leg of the
+ *     button should be attached to GND.
+ *
+ * Note on relay pin
+ *   Some people might want to use Wemos Relay Shield to test this example.
+ *   Now Wemos Relay Shield connects the relay to pin D1.
+ *   However, when using D1 as output, Serial communication will be blocked.
+ *   So you will either keep on using D1 and miss the Serial monitor
+ *   feedback, or connect your relay to another digital pin (e.g. D5).
+ *   (You can modify your Wemos Relay Shield for that, as I show it in this
+ *   video: https://youtu.be/GykA_7QmoXE)
+ */
+ 
+ /**
+ * Important: This example requires ESPAsyncWebServer library, https://github.com/me-no-dev/ESPAsyncWebServer
+ * Also for ESP8266 it requires ESPAsyncTCP, https://github.com/me-no-dev/ESPAsyncTCP
+ * For ESP32 it requires AsyncTCP, https://github.com/me-no-dev/AsyncTCP
+ * 
+ * To enable the use of the AsyncWebServer #define IOTWEBCONF_CONFIG_USE_ASYNC must be
+ * uncommented in IotWebConf.h, or otherwise defined.
+ */
+ 
+
+#include <MQTT.h>
+#include <IotWebConf.h>
+
+// -- Initial name of the Thing. Used e.g. as SSID of the own Access Point.
+const char thingName[] = "testThing";
+
+// -- Initial password to connect to the Thing, when it creates an own Access Point.
+const char wifiInitialApPassword[] = "smrtTHNG8266";
+
+#define STRING_LEN 128
+
+// -- Configuration specific key. The value should be modified if config structure was changed.
+#define CONFIG_VERSION "mqt2"
+
+// -- When BUTTON_PIN is pulled to ground on startup, the Thing will use the initial
+//      password to buld an AP. (E.g. in case of lost password)
+#define BUTTON_PIN D2
+
+// -- Status indicator pin.
+//      First it will light up (kept LOW), on Wifi connection it will blink,
+//      when connected to the Wifi it will turn off (kept HIGH).
+#define STATUS_PIN LED_BUILTIN
+
+// -- Connected ouput pin. See "Note on relay pin"!
+#define RELAY_PIN D5
+
+#define MQTT_TOPIC_PREFIX "/devices/"
+
+// -- Ignore/limit status changes more frequent than the value below (milliseconds).
+#define ACTION_FEQ_LIMIT 7000
+#define NO_ACTION -1
+
+// -- Callback method declarations.
+void wifiConnected();
+void configSaved();
+boolean formValidator(AsyncWebServerRequest *request);
+void mqttMessageReceived(String &topic, String &payload);
+
+DNSServer dnsServer;
+AsyncWebServer server(80);
+HTTPUpdateServer httpUpdater;
+WiFiClient net;
+MQTTClient mqttClient;
+
+char mqttServerValue[STRING_LEN];
+
+IotWebConf iotWebConf(thingName, &dnsServer, &server, wifiInitialApPassword, CONFIG_VERSION);
+IotWebConfParameter mqttServerParam = IotWebConfParameter("MQTT server", "mqttServer", mqttServerValue, STRING_LEN);
+
+boolean needMqttConnect = false;
+boolean needReset = false;
+unsigned long lastMqttConnectionAttempt = 0;
+int needAction = NO_ACTION;
+int state = LOW;
+unsigned long lastAction = 0;
+char mqttActionTopic[STRING_LEN];
+char mqttStatusTopic[STRING_LEN];
+
+void setup() 
+{
+  Serial.begin(115200); // See "Note on relay pin"!
+  Serial.println();
+  Serial.println("Starting up...");
+
+  pinMode(RELAY_PIN, OUTPUT);
+
+  iotWebConf.setStatusPin(STATUS_PIN);
+  iotWebConf.setConfigPin(BUTTON_PIN);
+  iotWebConf.addParameter(&mqttServerParam);
+  iotWebConf.setConfigSavedCallback(&configSaved);
+  iotWebConf.setFormValidator(&formValidator);
+  iotWebConf.setWifiConnectionCallback(&wifiConnected);
+  iotWebConf.setupUpdateServer(&httpUpdater);
+
+  // -- Initializing the configuration.
+  boolean validConfig = iotWebConf.init();
+  if (!validConfig)
+  {
+    mqttServerValue[0] = '\0';
+  }
+
+  // -- Set up required URL handlers on the web server.
+  server.on("/", handleRoot);
+  server.on("/config", [](AsyncWebServerRequest *request){ iotWebConf.handleConfig(request); });
+  server.onNotFound([](AsyncWebServerRequest *request){ iotWebConf.handleNotFound(request); });
+
+  // -- Prepare dynamic topic names
+  String temp = String(MQTT_TOPIC_PREFIX);
+  temp += iotWebConf.getThingName();
+  temp += "/action";
+  temp.toCharArray(mqttActionTopic, STRING_LEN);
+  temp = String(MQTT_TOPIC_PREFIX);
+  temp += iotWebConf.getThingName();
+  temp += "/status";
+  temp.toCharArray(mqttStatusTopic, STRING_LEN);
+
+  mqttClient.begin(mqttServerValue, net);
+  mqttClient.onMessage(mqttMessageReceived);
+  
+  Serial.println("Ready.");
+}
+
+void loop() 
+{
+  // -- doLoop should be called as frequently as possible.
+  iotWebConf.doLoop();
+  mqttClient.loop();
+  
+  if (needMqttConnect)
+  {
+    if (connectMqtt())
+    {
+      needMqttConnect = false;
+    }
+  }
+  else if ((iotWebConf.getState() == IOTWEBCONF_STATE_ONLINE) && (!mqttClient.connected()))
+  {
+    Serial.println("MQTT reconnect");
+    connectMqtt();
+  }
+
+  if (needReset)
+  {
+    Serial.println("Rebooting after 1 second.");
+    iotWebConf.delay(1000);
+    ESP.restart();
+  }
+
+  unsigned long now = millis();
+
+  // -- Check for button push
+  if ((digitalRead(BUTTON_PIN) == LOW)
+    && ( ACTION_FEQ_LIMIT < now - lastAction))
+  {
+    needAction = 1 - state; // -- Invert the state
+  }
+  
+  if ((needAction != NO_ACTION)
+    && ( ACTION_FEQ_LIMIT < now - lastAction))
+  {
+    state = needAction;
+    digitalWrite(RELAY_PIN, state);
+    if (state == HIGH)
+    {
+      iotWebConf.blink(5000, 95);
+    }
+    else
+    {
+      iotWebConf.stopCustomBlink();
+    }
+    mqttClient.publish(mqttStatusTopic, state == HIGH ? "ON" : "OFF", true, 1);
+    mqttClient.publish(mqttActionTopic, state == HIGH ? "ON" : "OFF", true, 1);
+    Serial.print("Switched ");
+    Serial.println(state == HIGH ? "ON" : "OFF");
+    needAction = NO_ACTION;
+    lastAction = now;
+  }
+}
+
+/**
+ * Handle web requests to "/" path.
+ */
+void handleRoot(AsyncWebServerRequest *request)
+{
+  // -- Let IotWebConf test and handle captive portal requests.
+  if (iotWebConf.handleCaptivePortal(request))
+  {
+    // -- Captive portal request were already served.
+    return;
+  }
+  String s = F("<!DOCTYPE html><html lang=\"en\"><head><meta name=\"viewport\" content=\"width=device-width, initial-scale=1, user-scalable=no\"/>");
+  s += iotWebConf.getHtmlFormatProvider()->getStyle();
+  s += "<title>IotWebConf 07 MQTT Relay</title></head><body>";
+  s += iotWebConf.getThingName();
+  s += "<div>State: ";
+  s += (state == HIGH ? "ON" : "OFF");
+  s += "</div>";
+  s += "<button type='button' onclick=\"location.href='';\" >Refresh</button>";
+  s += "<div>Go to <a href='config'>configure page</a> to change values.</div>";
+  s += "</body></html>\n";
+
+  request->send(200, "text/html", s);
+}
+
+void wifiConnected()
+{
+  needMqttConnect = true;
+}
+
+void configSaved()
+{
+  Serial.println("Configuration was updated.");
+  needReset = true;
+}
+
+boolean formValidator(AsyncWebServerRequest *request)
+{
+  Serial.println("Validating form.");
+  boolean valid = true;
+
+  int l = request->arg(mqttServerParam.getId()).length();
+  if (l < 3)
+  {
+    mqttServerParam.errorMessage = "Please provide at least 3 characters!";
+    valid = false;
+  }
+
+  return valid;
+}
+
+boolean connectMqtt() {
+  unsigned long now = millis();
+  if (1000 > now - lastMqttConnectionAttempt)
+  {
+    // Do not repeat within 1 sec.
+    return false;
+  }
+  Serial.println("Connecting to MQTT server...");
+  if (!mqttClient.connect(iotWebConf.getThingName())) {
+    lastMqttConnectionAttempt = now;
+    return false;
+  }
+  Serial.println("Connected!");
+
+  mqttClient.subscribe(mqttActionTopic);
+  mqttClient.publish(mqttStatusTopic, state == HIGH ? "ON" : "OFF", true, 1);
+  mqttClient.publish(mqttActionTopic, state == HIGH ? "ON" : "OFF", true, 1);
+
+  return true;
+}
+
+void mqttMessageReceived(String &topic, String &payload)
+{
+  Serial.println("Incoming: " + topic + " - " + payload);
+  
+  if (topic.endsWith("action"))
+  {
+    needAction = payload.equals("ON") ? HIGH : LOW;
+    if (needAction == state)
+    {
+      needAction = NO_ACTION;
+    }
+  }
+}
+

--- a/examples/Async_IotWebConf08WebRelay/Async_IotWebConf08WebRelay.ino
+++ b/examples/Async_IotWebConf08WebRelay/Async_IotWebConf08WebRelay.ino
@@ -1,0 +1,213 @@
+/**
+ * IotWebConf08WebRelay.ino -- IotWebConf is an ESP8266/ESP32
+ *   non blocking WiFi/AP web configuration library for Arduino.
+ *   https://github.com/prampec/IotWebConf 
+ *
+ * Copyright (C) 2018 Balazs Kelemen <prampec+arduino@gmail.com>
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+/**
+ * Example: Web Relay Demo
+ * Description:
+ *   All IotWebConf specific aspects of this example are described in
+ *   previous examples, so please get familiar with IotWebConf before
+ *   starting this example. So nothing new will be explained here, 
+ *   but a complete demo application will be built.
+ *   It is also expected from the reader to have a basic knowledge over
+ *   HTML to understand this code.
+ *   As an addition an example is show here with combining the chip-ID
+ *   into the initial thing name.
+ *   
+ *   This example stets up a web page, where switch action can take place.
+ *   The repay can be also altered with the push button. 
+ *   The thing will delay actions arriving within 10 seconds.
+ *   
+ *   This example also provides the firmware update option.
+ *   (See previous examples for more details!)
+ * 
+ * Hardware setup for this example:
+ *   - A Relay is attached to the D1 pin (On=HIGH)
+ *   - An LED is attached to LED_BUILTIN pin with setup On=LOW.
+ *   - A push button is attached to pin D2, the other leg of the
+ *     button should be attached to GND.
+ */
+ 
+ /**
+ * Important: This example requires ESPAsyncWebServer library, https://github.com/me-no-dev/ESPAsyncWebServer
+ * Also for ESP8266 it requires ESPAsyncTCP, https://github.com/me-no-dev/ESPAsyncTCP
+ * For ESP32 it requires AsyncTCP, https://github.com/me-no-dev/AsyncTCP
+ * 
+ * To enable the use of the AsyncWebServer #define IOTWEBCONF_CONFIG_USE_ASYNC must be
+ * uncommented in IotWebConf.h, or otherwise defined.
+ */
+
+#include <IotWebConf.h>
+
+#ifdef ESP8266
+String ChipId = String(ESP.getChipId(), HEX);
+#elif ESP32
+String ChipId = String((uint32_t)ESP.getEfuseMac(), HEX);
+#endif
+
+// -- Initial name of the Thing. Used e.g. as SSID of the own Access Point.
+String thingName = String("testThing-") + ChipId;
+
+// -- Initial password to connect to the Thing, when it creates an own Access Point.
+const char wifiInitialApPassword[] = "smrtTHNG8266";
+
+#define STRING_LEN 128
+
+// -- Configuration specific key. The value should be modified if config structure was changed.
+#define CONFIG_VERSION "web1"
+
+// -- When BUTTON_PIN is pulled to ground on startup, the Thing will use the initial
+//      password to buld an AP. (E.g. in case of lost password)
+#define BUTTON_PIN D2
+
+// -- Status indicator pin.
+//      First it will light up (kept LOW), on Wifi connection it will blink,
+//      when connected to the Wifi it will turn off (kept HIGH).
+#define STATUS_PIN LED_BUILTIN
+
+// -- Connected ouput pin.
+#define RELAY_PIN D1
+
+#define ACTION_FEQ_LIMIT 10000
+#define NO_ACTION -1
+
+// -- Callback method declarations.
+void configSaved();
+
+DNSServer dnsServer;
+AsyncWebServer server(80);
+HTTPUpdateServer httpUpdater;
+
+IotWebConf iotWebConf(thingName.c_str(), &dnsServer, &server, wifiInitialApPassword, CONFIG_VERSION);
+
+boolean needReset = false;
+int needAction = NO_ACTION;
+int state = LOW;
+unsigned long lastAction = 0;
+
+void setup() 
+{
+  Serial.begin(115200);
+  Serial.println();
+  Serial.println("Starting up...");
+
+  pinMode(RELAY_PIN, OUTPUT);
+
+  iotWebConf.setStatusPin(STATUS_PIN);
+  iotWebConf.setConfigPin(BUTTON_PIN);
+  iotWebConf.setConfigSavedCallback(&configSaved);
+  iotWebConf.setupUpdateServer(&httpUpdater);
+
+  // -- Initializing the configuration.
+  iotWebConf.init();
+
+  // -- Set up required URL handlers on the web server.
+  server.on("/", handleRoot);
+  server.on("/config", [](AsyncWebServerRequest *request){ iotWebConf.handleConfig(request); });
+  server.onNotFound([](AsyncWebServerRequest *request){ iotWebConf.handleNotFound(request); });
+
+  Serial.println("Ready.");
+}
+
+void loop() 
+{
+  // -- doLoop should be called as frequently as possible.
+  iotWebConf.doLoop();
+
+  if (needReset)
+  {
+    Serial.println("Rebooting after 1 second.");
+    iotWebConf.delay(1000);
+    ESP.restart();
+  }
+
+  unsigned long now = millis();
+
+  // -- Check for button push
+  if ((digitalRead(BUTTON_PIN) == LOW)
+    && (ACTION_FEQ_LIMIT < now - lastAction))
+  {
+    needAction = 1 - state; // -- Invert the state
+  }
+
+  applyAction(now);
+}
+
+void applyAction(unsigned long now)
+{
+  if ((needAction != NO_ACTION)
+    && (ACTION_FEQ_LIMIT < now - lastAction))
+  {
+    state = needAction;
+    digitalWrite(RELAY_PIN, state);
+    if (state == HIGH)
+    {
+      iotWebConf.blink(5000, 95);
+    }
+    else
+    {
+      iotWebConf.stopCustomBlink();
+    }
+    Serial.print("Switched ");
+    Serial.println(state == HIGH ? "ON" : "OFF");
+    needAction = NO_ACTION;
+    lastAction = now;
+  }
+}
+
+/**
+ * Handle web requests to "/" path.
+ */
+void handleRoot(AsyncWebServerRequest *request)
+{
+  // -- Let IotWebConf test and handle captive portal requests.
+  if (iotWebConf.handleCaptivePortal(request))
+  {
+    // -- Captive portal request were already served.
+    return;
+  }
+
+  if (request->hasArg("action"))
+  {
+    String action = request->arg("action");
+    if (action.equals("on"))
+    {
+      needAction = HIGH;
+    }
+    else if (action.equals("off"))
+    {
+      needAction = LOW;
+    }
+    applyAction(millis());
+  }
+  
+  String s = F("<!DOCTYPE html><html lang=\"en\"><head><meta name=\"viewport\" content=\"width=device-width, initial-scale=1, user-scalable=no\"/>");
+  s += iotWebConf.getHtmlFormatProvider()->getStyle();
+  s += "<title>IotWebConf 08 Web Relay</title></head><body>";
+  s += iotWebConf.getThingName();
+  s += "<div>State: ";
+  s += (state == HIGH ? "ON" : "OFF");
+  s += "</div>";
+  s += "<div>";
+  s += "<button type='button' onclick=\"location.href='?action=on';\" >Turn ON</button>";
+  s += "<button type='button' onclick=\"location.href='?action=off';\" >Turn OFF</button>";
+  s += "<button type='button' onclick=\"location.href='?';\" >Refresh</button>";
+  s += "</div>";
+  s += "<div>Go to <a href='config'>configure page</a> to change values.</div>";
+  s += "</body></html>\n";
+
+  request->send(200, "text/html", s);
+}
+
+void configSaved()
+{
+  Serial.println("Configuration was updated.");
+  needReset = true;
+}

--- a/examples/Async_IotWebConf09CustomConnection/Async_IotWebConf09CustomConnection.ino
+++ b/examples/Async_IotWebConf09CustomConnection/Async_IotWebConf09CustomConnection.ino
@@ -24,6 +24,15 @@
  *   - [Optional] A push button is attached to pin D2, the other leg of the
  *     button should be attached to GND.
  */
+ 
+ /**
+ * Important: This example requires ESPAsyncWebServer library, https://github.com/me-no-dev/ESPAsyncWebServer
+ * Also for ESP8266 it requires ESPAsyncTCP, https://github.com/me-no-dev/ESPAsyncTCP
+ * For ESP32 it requires AsyncTCP, https://github.com/me-no-dev/AsyncTCP
+ * 
+ * To enable the use of the AsyncWebServer #define IOTWEBCONF_CONFIG_USE_ASYNC must be
+ * uncommented in IotWebConf.h, or otherwise defined.
+ */
 
 #include <IotWebConf.h>
 

--- a/examples/Async_IotWebConf10CustomHtml/Async_IotWebConf10CustomHtml.ino
+++ b/examples/Async_IotWebConf10CustomHtml/Async_IotWebConf10CustomHtml.ino
@@ -1,0 +1,125 @@
+/**
+ * IotWebConf01Minimal.ino -- IotWebConf is an ESP8266/ESP32
+ *   non blocking WiFi/AP web configuration library for Arduino.
+ *   https://github.com/prampec/IotWebConf 
+ *
+ * Copyright (C) 2018 Balazs Kelemen <prampec+arduino@gmail.com>
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+/**
+ * Example: Custom HTML
+ * Description:
+ *   This example demostrates how to override the default look and feel of the
+ *   config portal.
+ * 
+ *   The first customalization is to add a logo to the config page.
+ * 
+ *   The second customalization is a special javascript, that detects all
+ *   password fields, and adds a small button after each of them with a
+ *   lock on it. By pressing the lock the password became visible/hidden.
+ */
+ 
+ /**
+ * Important: This example requires ESPAsyncWebServer library, https://github.com/me-no-dev/ESPAsyncWebServer
+ * Also for ESP8266 it requires ESPAsyncTCP, https://github.com/me-no-dev/ESPAsyncTCP
+ * For ESP32 it requires AsyncTCP, https://github.com/me-no-dev/AsyncTCP
+ * 
+ * To enable the use of the AsyncWebServer #define IOTWEBCONF_CONFIG_USE_ASYNC must be
+ * uncommented in IotWebConf.h, or otherwise defined.
+ */
+
+#include <IotWebConf.h>
+
+// -- Initial name of the Thing. Used e.g. as SSID of the own Access Point.
+const char thingName[] = "testThing";
+
+// -- Initial password to connect to the Thing, when it creates an own Access Point.
+const char wifiInitialApPassword[] = "smrtTHNG8266";
+
+DNSServer dnsServer;
+AsyncWebServer server(80);
+
+IotWebConf iotWebConf(thingName, &dnsServer, &server, wifiInitialApPassword);
+
+// -- Javascript block will be added to the header.
+const char CUSTOMHTML_SCRIPT_INNER[] PROGMEM = "\n\
+document.addEventListener('DOMContentLoaded', function(event) {\n\
+  let elements = document.querySelectorAll('input[type=\"password\"]');\n\
+  for (let p of elements) {\n\
+  	let btn = document.createElement('INPUT'); btn.type = 'button'; btn.value = '🔓'; btn.style.width = 'auto'; p.style.width = '83%'; p.parentNode.insertBefore(btn,p.nextSibling);\n\
+    btn.onclick = function() { if (p.type === 'password') { p.type = 'text'; btn.value = '🔒'; } else { p.type = 'password'; btn.value = '🔓'; } }\n\
+  };\n\
+});\n";
+// -- HTML element will be added inside the body element.
+const char CUSTOMHTML_BODY_INNER[] PROGMEM = "<div><img src='data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAS8AAABaBAMAAAAbaM0tAAAAMFBMVEUAAQATFRIcHRsmKCUuLy3TCAJnaWbmaWiHiYYkquKsqKWH0vDzurrNzsvg5+j9//wjKRqOAAAAAWJLR0QAiAUdSAAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB+MHBhYoILXXEeAAAAewSURBVGje7ZrBaxtXEIfHjlmEwJFOvbXxKbc2/gfa6FRyKTkJX1KyIRCCIfXJ+BLI0gYTAknOwhA7FxMKts7GEJ9CLmmtlmKMCZZzKbGdZBXiOIqc3e2bmfd232pXalabalXwg4jNWm/1aWbeb+bNE3iDORpwDHYMdgz2fwBbsQcVbO0YLBnY7vyAgn2YzzzgOoDdD67dSrZgRxqLdzSnQc5l68oPlQ5gK13iDSDRRxV6AXMr87r7unnSmQW4umT3Cczb1U1W6eJJxwQchX6BhUwWmCnqyRr0FyxkMl9hjyKedAHyde/Vw/N9AwuZrLMnW2D0Nfjbo0xZLAJ7CKP9BgtM5m7dmr31q/2vzxdgLdOo0vXeLHyxrN6wWCrQ6jWW+XmzcLXeO5i3y37buszhDbl67IyTGpgj3kau3aQZ9xjsL1wbrqnueAv4sBRgrFk3wR/Dd7W/ripX6jG2oz6cJxhMTouWV2+OwhKH1TuYty/+XQJ9/KRFILu2KT5s2wezll2LTAiTtrtJjA3IGeINbhGu2XsAVRQYo47q1zuYGA+I5wRcuQJFcTFU9XXjvi8XQviXJVgeTShevLsscSfxkWTCJhmL7ph4o5kOjFxjLDHC4hjAiPLyXFhgrzHYFDoqF0hJnsD4SVOEl/ccvpEKzBEoUNU0C+A7VtxAaIXvgsCqogmNQHxz+Mg8Bzw+xxF3mupGCrA/hLl0lXBKMFynANOL7U1cb3kCa0vlyNhgoTPpb54wuVS+WgowR4QVcnycmVlXaxC+1AJMjS2TmJSPpI7h8PWkpNaPurGTAuxA6s77clmCCQcM214lJjHhOzWwpsJQCgwaWCGd8qP5KRp8sGfraMSz3m40CSxgbGtg1mcHc229cMCAvb7+rlxGx5bLFzHsjLiJ5JgATFjwjvStBChCW65I6soPlbk1Txd1wVMuT7DdbuC6gnqnlBmAsZi5GpjpT+sx+I8qlcqcLf9zhnnEmHnqvWOHWsKXcRY7pYMxjaOBLfiy06tcuKuI9oimYui/K8sxTQ5VutQ9xthdhxpYzU/2KQRWorEsPS4H4zr550SoHqvLD6tGXbmggTVZEZ2pdClpX5B5Y/yfpzNhNDMUZA24ve29sigcAzDxscveZk4D4xJ8yyykTeL7867vMxH80xJsQmW9YAaPkyEwSu3wlQambVqaKcseR0XFR1yOzxjtR7Um2sBydgiMMAxbB+OcatTTF4otNZP1VSyCmWkUjKZWs2LZPWuCcdv2wmDeInxf1XUMq5PxEX6fk660bsJ5H4wWgXDj03W05Gi23Z6m+kos/NPlCyoh5AcGbIJWwEVVzGQMxjHmoBMvyBUgLTZ6VFldtTMDcyj3PMaQv6CXPg6C4VjLCMwli5FKTFz/jQONXXzKe726UqnMZwTmjYvV5waiP1EP771fZ2UxzzRUbaHQbnAhcS/j5nBtGKvWJ9MBGa1LC+yMwd5yCfWeJJ8GWswtGpm20/dRL874wv/eB2uEMlL/2+m4ox3L+fqKLy+fcAX7mUPsk7pqCuyIyusa+ZLAHquE1OryHICEVigkBXMr1ALg6vzl7yRnMiFZ8E12YO6KVHXTd9vMzA25xRmqZwemuHA3EcZojcPX3mcG+/TgX6k8CjY/ubZOAIrY/YzAdoMPdk34IfjrYpFaFEed0vd/DebqDR/fZO5Dv9e5MtcFLGhdmyzQtOXEXtWkrZrYMBnsFuTXaYlyu9re+t70q/boeeWOrAoXikF3ONKGCoOp1jUTMd/fqjMswHCjMtUG5oyLy5F6uPW94R8GxYDVcmoZwFDO9jvDa13AVOt6h3KEi2HpgGo7chObW40a2AJd50PzXegG9ielbKc0PDKpLdB4Z0ow1bpmGaSe7HMwtt0Fbsnm8vYLWkOaXDjYxd0gDdDni12zuzUVD9YiKWtttx3dxFaJEky1rh1qJR/gporymIM4DWomkHs1sENys8UNEDX/jbYdi4AdlrTmsH5qstYZzG9dkwWw3SQbxpZ4VkOG370QGPekqF0bzNdXbRQMTteTpWOtdU12wpcWb6xq4pKbRTsc/T6YRV+fzgKC+QfadizqytJ5LymYHfQJCmy2Qy6VGmILzVUTMWlg3KhxECeYL+T8tt0J7MW4kRjMv8Sv3MJAO1AN2IKkaQcrEg11uLT5ppCNOx3AAE73DoaHrIfydKQ7mMwZwaWcLyUkBqyWZNfdDoYStiPPk3oB85xFdZIYAUv0g7J2MFQFkv83wfpK4kpEs9hk7RzuL1BPASaoSLG08+l4sFDwh+oBeeYePX07UU0BJrRBBku+O1hILkJgrnpS+KPeDtXTuLIpM7cDYHcFCwlsuIKKB3OgmgYMc/coaz7VSxshMOngSEryb9Y7u7JVPJsGzFPFgSgYlnCNhcCa3JGNJHH/sMBYsl/FB79TTLS7jYJZcrU7bWde9Op2KHuCUwwasdXFWKJ2axSspnYzL9QBtQbGNLJQLAaFol8LWaq6jII9h3RgwY8f9i7DueVw8HvuYikorW/CuWpb69t9WOJ6PCbGyBMbXuYjIvRWXh12DRjYG9j+GZKof7/AdtQxy8C5EgCy/6V1bD0GA/GD9QjY3qVw92JgwIRWfDugYIMxjsESg/0DuDZiWzBJr80AAAAASUVORK5CYII='/></div>\n";
+
+// -- This is an OOP technique to override behaviour of the existing
+// IotWebConfHtmlFormatProvider. Here two method are overriden from
+// the original class. See IotWebConf.h for all potentially overridable
+// methods of IotWebConfHtmlFormatProvider .
+class CustomHtmlFormatProvider : public IotWebConfHtmlFormatProvider
+{
+protected:
+  String getScriptInner() override
+  {
+    return
+      IotWebConfHtmlFormatProvider::getScriptInner() +
+      String(FPSTR(CUSTOMHTML_SCRIPT_INNER));
+  }
+  String getBodyInner() override
+  {
+    return
+      String(FPSTR(CUSTOMHTML_BODY_INNER)) +
+      IotWebConfHtmlFormatProvider::getBodyInner();
+  }
+};
+// -- An instance must be created from the class defined above.
+CustomHtmlFormatProvider customHtmlFormatProvider;
+
+void setup() 
+{
+  Serial.begin(115200);
+  Serial.println();
+  Serial.println("Starting up...");
+
+  // -- Applying the new HTML format to IotWebConf.
+  iotWebConf.setHtmlFormatProvider(&customHtmlFormatProvider);
+  iotWebConf.init();
+
+  // -- Set up required URL handlers on the web server.
+  server.on("/", handleRoot);
+  server.on("/config", [](AsyncWebServerRequest *request){ iotWebConf.handleConfig(request); });
+  server.onNotFound([](AsyncWebServerRequest *request){ iotWebConf.handleNotFound(request); });
+
+  Serial.println("Ready.");
+}
+
+void loop() 
+{
+  // -- doLoop should be called as frequently as possible.
+  iotWebConf.doLoop();
+}
+
+/**
+ * Handle web requests to "/" path.
+ */
+void handleRoot(AsyncWebServerRequest *request)
+{
+  // -- Let IotWebConf test and handle captive portal requests.
+  if (iotWebConf.handleCaptivePortal(request))
+  {
+    // -- Captive portal request were already served.
+    return;
+  }
+  String s = "<!DOCTYPE html><html lang=\"en\"><head><meta name=\"viewport\" content=\"width=device-width, initial-scale=1, user-scalable=no\"/>";
+  s += "<title>IotWebConf 10 Custom HTML</title></head><body>";
+  s += FPSTR(CUSTOMHTML_BODY_INNER);
+  s += "Go to <a href='config'>configure page</a> to change settings.";
+  s += "</body></html>\n";
+
+  request->send(200, "text/html; charset=UTF-8", s);
+}
+

--- a/examples/Async_IotWebConf11AdvancedRuntime/Async_IotWebConf11AdvancedRuntime.ino
+++ b/examples/Async_IotWebConf11AdvancedRuntime/Async_IotWebConf11AdvancedRuntime.ino
@@ -1,0 +1,213 @@
+/**
+ * IotWebConf11Advanced.ino -- IotWebConf is an ESP8266/ESP32
+ *   non blocking WiFi/AP web configuration library for Arduino.
+ *   https://github.com/prampec/IotWebConf 
+ *
+ * Copyright (C) 2018 Balazs Kelemen <prampec+arduino@gmail.com>
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+/**
+ * Example: Advanced runtime options
+ * Description:
+ *   The purpose of this example is to show the advanced non-GUI
+ *   options that can be used by application developers.
+ *   This example opens a serial terminal where we can send
+ *   commands to the code, mimicing an application, that needs
+ *   to change IotWebConf behavior runtime according to some
+ *   internal logic.
+ *   Please see this source code for available commands!
+ * 
+ * Hardware setup for this example:
+ *   - An LED is attached to LED_BUILTIN pin with setup On=LOW.
+ *     This is hopefully already attached by default.
+ *   - Serial monitor is set up with baud 115200 in bi-direction mode.
+ */
+ 
+ /**
+ * Important: This example requires ESPAsyncWebServer library, https://github.com/me-no-dev/ESPAsyncWebServer
+ * Also for ESP8266 it requires ESPAsyncTCP, https://github.com/me-no-dev/ESPAsyncTCP
+ * For ESP32 it requires AsyncTCP, https://github.com/me-no-dev/AsyncTCP
+ * 
+ * To enable the use of the AsyncWebServer #define IOTWEBCONF_CONFIG_USE_ASYNC must be
+ * uncommented in IotWebConf.h, or otherwise defined.
+ */
+
+#include <IotWebConf.h>
+
+// -- Initial name of the Thing. Used e.g. as SSID of the own Access Point.
+const char thingName[] = "testThing";
+
+// -- Initial password to connect to the Thing, when it creates an own Access Point.
+const char wifiInitialApPassword[] = "smrtTHNG8266";
+
+// -- Status indicator pin.
+//      First it will light up (kept LOW), on Wifi connection it will blink,
+//      when connected to the Wifi it will turn off (kept HIGH).
+#define STATUS_PIN LED_BUILTIN
+
+#define COMMAND_PARAMETER_LENGTH 30
+
+void handleRoot(AsyncWebServerRequest *request);
+void processCommand();
+
+DNSServer dnsServer;
+AsyncWebServer server(80);
+
+IotWebConf iotWebConf(thingName, &dnsServer, &server, wifiInitialApPassword);
+
+char commandParameter[COMMAND_PARAMETER_LENGTH];
+char labelBuffer[COMMAND_PARAMETER_LENGTH];
+
+void setup() 
+{
+  Serial.begin(115200);
+  Serial.println();
+  Serial.println("Starting up...");
+
+  // -- Initializing the configuration.
+  iotWebConf.setStatusPin(STATUS_PIN);
+  iotWebConf.init();
+
+  // -- Set up required URL handlers on the web server.
+  server.on("/", handleRoot);
+  server.on("/config", [](AsyncWebServerRequest *request){ iotWebConf.handleConfig(request); });
+  server.onNotFound([](AsyncWebServerRequest *request){ iotWebConf.handleNotFound(request); });
+
+  Serial.println("Ready.");
+}
+
+void loop() 
+{
+  // -- doLoop should be called as frequently as possible.
+  iotWebConf.doLoop();
+
+  if (Serial.available())
+  {
+    processCommand();
+  }
+}
+
+/**
+ * Handle web requests to "/" path.
+ */
+void handleRoot(AsyncWebServerRequest *request)
+{
+  // -- Let IotWebConf test and handle captive portal requests.
+  if (iotWebConf.handleCaptivePortal(request))
+  {
+    // -- Captive portal request were already served.
+    return;
+  }
+  String s = "<!DOCTYPE html><html lang=\"en\"><head><meta name=\"viewport\" content=\"width=device-width, initial-scale=1, user-scalable=no\"/>";
+  s += "<title>IotWebConf 02 Status and Reset</title></head><body>Hello world!";
+  s += "Go to <a href='config'>configure page</a> to change settings.";
+  s += "</body></html>\n";
+
+  request->send(200, "text/html", s);
+}
+
+void processCommand()
+{
+  char command = Serial.read();
+  delay(10);
+
+  byte commandParameterIndex = 0;
+  while(Serial.available())
+  {
+    char c = Serial.read();
+    if (c < 32)
+    {
+      continue;
+    }
+    if (commandParameterIndex < (COMMAND_PARAMETER_LENGTH - 2))
+    {
+      commandParameter[commandParameterIndex] = c;
+      commandParameterIndex += 1;
+    }
+  }
+  commandParameter[commandParameterIndex] = '\0';
+
+  switch (command)
+  {
+    case 'a':
+      // -- a1 - force AP mode
+      // -- a0 - stop forcing AP mode
+      if (commandParameter[0] == '1')
+      {
+        iotWebConf.forceApMode(true);
+        Serial.println(F(">> Force AP mode started"));
+      }
+      else if (commandParameter[0] == '0')
+      {
+        iotWebConf.forceApMode(false);
+        Serial.println(F(">> Force AP mode stopped"));
+      }
+      break;
+    case 'b':
+      // -- b1 - start blink in "percend" mode
+      // -- b2 - start blink in "fine" mode
+      // -- b0 - stop blinking (started by the options above)
+      if (commandParameter[0] == '1')
+      {
+        iotWebConf.blink(2000, 70);
+        Serial.println(F(">> Started custom blinking with repeat of 2000ms and 70% on state."));
+      }
+      else if (commandParameter[0] == '2')
+      {
+        iotWebConf.fineBlink(100, 600);
+        Serial.println(F(">> Started custom blinking with repeat of 100ms ON and 600ms OFF state."));
+      }
+      else if (commandParameter[0] == '0')
+      {
+        iotWebConf.stopCustomBlink();
+        Serial.println(F(">> Custom blinking stopped."));
+      }
+      break;
+    case 's':
+      // -- s - Get current state
+      Serial.print(F(">> State is :"));
+      Serial.println(iotWebConf.getState());
+      break;
+    case 't':
+      // -- t1 - Sets the AP timeout to 60 secs
+      // -- t0 - Sets the AP timeout to the default
+      if (commandParameter[0] == '1')
+      {
+        iotWebConf.setApTimeoutMs(60000);
+        Serial.println(F(">> AP timeout was changed to 60secs."));
+      }
+      else if (commandParameter[0] == '0')
+      {
+        iotWebConf.setApTimeoutMs(IOTWEBCONF_DEFAULT_AP_MODE_TIMEOUT_MS);
+        Serial.print(F(">> AP timeout was changed to default (ms):"));
+        Serial.println(IOTWEBCONF_DEFAULT_AP_MODE_TIMEOUT_MS);
+      }
+      break;
+    case 'n':
+      // -- n<name> - Sets the thing name
+      strncpy(
+        iotWebConf.getThingNameParameter()->valueBuffer,
+        commandParameter,
+        iotWebConf.getThingNameParameter()->getLength());
+      iotWebConf.configSave();
+      Serial.print(F(">> Thing name was changed to '"));
+      Serial.print(commandParameter);
+      Serial.println(F("'"));
+      break;
+    case 'l':
+      // -- l<label> - Sets the label for config item thing-name.
+      strncpy(
+        labelBuffer,
+        commandParameter,
+        COMMAND_PARAMETER_LENGTH);
+      iotWebConf.getThingNameParameter()->label = labelBuffer;
+      Serial.print(F(">> Thing name label was temporary changed to '"));
+      Serial.print(labelBuffer);
+      Serial.println(F("'"));
+      break;
+  }
+
+}

--- a/src/IotWebConfAsyncUpdater.cpp
+++ b/src/IotWebConfAsyncUpdater.cpp
@@ -1,0 +1,125 @@
+/**
+ * IotWebConfCompatibility.cpp -- IotWebConf is an ESP8266/ESP32
+ *   non blocking WiFi/AP web configuration library for Arduino.
+ *   https://github.com/prampec/IotWebConf
+ *
+ * Copyright (C) 2018 Balazs Kelemen <prampec+arduino@gmail.com>
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ *
+ * Notes on IotWebConfCompatibility:
+ * This file contains workarounds, and borrowed codes from other projects,
+ * to keep IotWebConf code more simple and more general. See details
+ * in comments for code segments in IotWebConfCompatibility.h .
+ *
+ */
+
+/**
+ * NOTE: Lines starting with /// are changed by IotWebConf
+ */
+#include "IotWebConfAsyncUpdater.h"
+#ifdef IOTWEBCONF_CONFIG_USE_ASYNC
+
+static const char serverIndex[] PROGMEM =
+  R"(<html><body><form method='POST' action='' enctype='multipart/form-data'>
+                  <input type='file' name='update'>
+                  <input type='submit' value='Update'>
+               </form>
+         </body></html>)";
+static const char successResponse[] PROGMEM =
+  "<META http-equiv=\"refresh\" content=\"15;URL=/\">Update Success! Rebooting...\n";
+
+AsyncHTTPUpdateServer::AsyncHTTPUpdateServer(bool serial_debug)
+{
+  _serial_output = serial_debug;
+  _server = NULL;
+  _username = emptyString;
+  _password = emptyString;
+  _authenticated = false;
+  _restartRequired = false;
+}
+
+void AsyncHTTPUpdateServer::setup(AsyncWebServer *server, const String& path, const String& username, const String& password)
+{
+    _server = server;
+    _username = username;
+    _password = password;
+
+    // handler for the /update form page
+    _server->on(path.c_str(), HTTP_GET, [&](AsyncWebServerRequest *request){
+      if(_username != emptyString && _password != emptyString && !request->authenticate(_username.c_str(), _password.c_str()))
+        return request->requestAuthentication();
+      request->send_P(200, PSTR("text/html"), serverIndex);
+    });
+
+    // handler for the /update form POST (once file upload finishes)
+    _server->on(path.c_str(), HTTP_POST, [&](AsyncWebServerRequest *request){
+      if(!_authenticated)
+        return request->requestAuthentication();
+      if (Update.hasError()) {
+        request->send(200, F("text/html"), String(F("Update error: ")) + _updaterError);
+      } else {
+        if (_serial_output)
+          Serial.println("\nUpdate complete");
+        request->send_P(200, PSTR("text/html"), successResponse);
+        _restartRequired = true;
+      }
+    },[&](AsyncWebServerRequest *request, const String& filename, size_t index, uint8_t *data,
+          size_t len, bool final)
+    {
+      // handler for the file upload, get's the sketch bytes, and writes
+      // them through the Update object
+      if (!index){
+        _updaterError = String();
+        if (_serial_output)
+          Serial.setDebugOutput(true);
+
+        _authenticated = (_username == emptyString || _password == emptyString || request->authenticate(_username.c_str(), _password.c_str()));
+        if(!_authenticated){
+          if (_serial_output) {
+            Serial.printf("Unauthenticated Update\n");
+            return;
+          }
+        }
+
+        if (_serial_output)
+          Serial.printf("Update: %s\n", filename.c_str());
+        //content_len = request->contentLength();
+        // if filename includes spiffs, update the spiffs partition
+        int cmd = (filename.indexOf("spiffs") > -1) ? U_SPIFFS : U_FLASH;
+#ifdef ESP8266
+        Update.runAsync(true);
+        if (!Update.begin(content_len, cmd)) {
+#else
+        if (!Update.begin(UPDATE_SIZE_UNKNOWN, cmd)) {
+#endif
+          _setUpdaterError();
+        }
+      }
+
+      if(_authenticated && !_updaterError.length()){
+        if (_serial_output) Serial.printf(".");
+        if (Update.write(data, len) != len) {
+          _setUpdaterError();
+        }
+      }
+
+      if (final && _authenticated && !_updaterError.length()) {
+        if (!Update.end(true)){
+          _setUpdaterError();
+        }
+        Serial.setDebugOutput(false);
+      }
+   });
+}
+
+void AsyncHTTPUpdateServer::_setUpdaterError()
+{
+  if (_serial_output) Update.printError(Serial);
+  StreamString str;
+  Update.printError(str);
+  _updaterError = str.c_str();
+}
+
+#endif

--- a/src/IotWebConfAsyncUpdater.h
+++ b/src/IotWebConfAsyncUpdater.h
@@ -1,0 +1,86 @@
+/**
+ * IotWebConfCompatibility.h -- IotWebConf is an ESP8266/ESP32
+ *   non blocking WiFi/AP web configuration library for Arduino.
+ *   https://github.com/prampec/IotWebConf
+ *
+ * Copyright (C) 2018 Balazs Kelemen <prampec+arduino@gmail.com>
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ *
+ * Notes on IotWebConfAsyncUpdater:
+ * This file contains workarounds, and borrowed codes from other projects,
+ * to keep IotWebConf code more simple and more general. See details
+ * in comments for code segments bellow this file.
+ *
+ */
+
+#ifndef __ASYNC_HTTP_UPDATE_SERVER_H
+#define __ASYNC_HTTP_UPDATE_SERVER_H
+
+#include <IotWebConf.h>
+#ifdef IOTWEBCONF_CONFIG_USE_ASYNC
+
+#include <ESPAsyncWebServer.h>
+#ifdef ESP8266
+#include <Updater.h>
+#include <ESP8266mDNS.h>
+#else
+#include <Update.h>
+#include <ESPmDNS.h>
+#endif
+#include <StreamString.h>
+
+#define emptyString F("")
+
+class AsyncWebServer;
+
+class AsyncHTTPUpdateServer
+{
+  public:
+    AsyncHTTPUpdateServer(bool serial_debug=false);
+
+    void setup(AsyncWebServer *server)
+    {
+      setup(server, emptyString, emptyString);
+    }
+
+    void setup(AsyncWebServer *server, const String& path)
+    {
+      setup(server, path, emptyString, emptyString);
+    }
+
+    void setup(AsyncWebServer *server, const String& username, const String& password)
+    {
+      setup(server, "/update", username, password);
+    }
+
+    void setup(AsyncWebServer *server, const String& path, const String& username, const String& password);
+
+    void updateCredentials(const String& username, const String& password)
+    {
+      _username = username;
+      _password = password;
+    }
+
+    bool restartRequired()
+    {
+        return _restartRequired;
+    }
+
+  protected:
+    void _setUpdaterError();
+
+  private:
+    bool _serial_output;
+    AsyncWebServer *_server;
+    String _username;
+    String _password;
+    bool _authenticated;
+    String _updaterError;
+    bool _restartRequired;
+};
+
+#endif
+
+#endif


### PR DESCRIPTION
First, I just want to say thank you for this great tool!

I've been using a modified version of this library to use async for a while and since a couple people have posted about this I thought I'd share it.

* Does not change existing code, just uses async when enabled.

* Added refactored versions of the examples to show how to use async.

* To use, just uncomment `#define IOTWEBCONF_CONFIG_USE_ASYNC` in IotWebConf.h and make sure you have the  
ESPAsyncWebServer and AsyncTCP (for ESP32) or ESPAsyncTCP (for ESP8266).

**This has not been tested with the ESP8266** so I am unsure if anything is missing for this to work on that platform. If anything needs changed please let me know.

@prampec I know you're busy with your upcoming release, no expectation to merge this anytime soon. Just wanted to put this out there for anyone interested.