### PR TITLE
Fix: Redirect to "/config" on handleCaptivePortal

### DIFF
--- a/src/IotWebConf.cpp
+++ b/src/IotWebConf.cpp
@@ -720,7 +720,7 @@ boolean IotWebConf::handleCaptivePortal()
     Serial.println(this->_server->client().localIP());
 #endif
     this->_server->sendHeader(
-      "Location", String("http://") + toStringIp(this->_server->client().localIP()), true);
+      "Location", String("http://") + toStringIp(this->_server->client().localIP()) + "/config", true);
     this->_server->send(302, "text/plain", ""); // Empty content inhibits Content-length header so we have to close the socket ourselves.
     this->_server->client().stop(); // Stop is needed because we sent no content length
     return true;


### PR DESCRIPTION
Hi,
I like this library, but when using it in a project, it displays my root page when it should display the captive portal.
Maybe I am using it wrong.
```
  server.on("/", handleRoot);
  server.on("/config", []{ iotWebConf.handleConfig(); });
  server.onNotFound([](){ iotWebConf.handleNotFound(); });
//...
void handleRoot() {
  // -- Let IotWebConf test and handle captive portal requests.
  if (iotWebConf.handleCaptivePortal())
  {
    // -- Captive portal request were already served.
    return;
  }
  server.send(200, "text/html", INDEX_HTML);
}
```
But if I change the redirect in handleCaptivePortal, it will redirect correctly to the "/config" page when connecting.

Or should I handle the config on "/" and use the `setWifiConnectionCallback` to change the on("/") to handle my root after successfull connection?