### PR TITLE
HTTPS Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ Also visit experimental [Discord server](https://discord.gg/GR3uQeD).
   - Automatic "Sign in to network" pop up in your browser (captive portal),
   - Non-blocking - Your custom code will not be blocked in the whole process.
   - Well documented header file, and examples from simple to complex levels.
+  - Supports HTTP or HTTPS
 
 ![Screenshot](https://sharedinventions.com/wp-content/uploads/2018/11/Screenshot_20181105-191748a.png)
 ![Screenshot](https://sharedinventions.com/wp-content/uploads/2019/02/Screenshot-from-2019-02-03-22-16-51b.png)
-  
+
 ## How it works
 The idea is that the Thing will provide a web interface to allow modifying its configuration. E.g. for connecting to a local WiFi network, it needs the SSID and the password.
 
@@ -57,7 +58,7 @@ tzapu's WiFiManager is a great library. The features of IotWebConf may appear ve
   - The initial system password must be modified by the user, so there is no build-in password.
   - When connecting in AP mode, the WiFi provides an encryption layer, so all you communication here is known to be safe.
   - When connecting through a WiFi router (WiFi mode), the Thing will ask for authentication when someone requests the config portal. This is required as the Thing will be visible for all devices sharing the same network. But be warned by the following note...
-  - NOTE: **When connecting through a WiFi router (WiFi mode), your communication is not hidden from devices connecting to the same network.** So either: Do not allow ambiguous devices connecting to your WiFi router, or configure your Thing only in AP mode!
+  - NOTE: **When connecting through a WiFi router (WiFi mode), your communication is not hidden from devices connecting to the same network unless you use HTTPS.** So either: Do not allow ambiguous devices connecting to your WiFi router, configure your Thing only in AP mode, or use HTTPS!
   - However IotWebConf has a detailed debug output, passwords are not shown in this log by default. You have
   to enable password visibility manually in the IotWebConf.h with the IOTWEBCONF_DEBUG_PWD_TO_SERIAL
   if it is needed.
@@ -67,7 +68,7 @@ IotWebConf is primary built for ESP8266. But meanwhile it was discovered, that t
 to ESP32. There are two major problems.
   - ESP8266 uses specific naming for it's classes (e.g. ESP8266WebServer). However ESP32 uses a more generic naming (e.g. WebServer). The idea here is to use the generic naming hoping that ESP8266 will adopt these "standards" sooner or later.
   - ESP32 does not provides an HTTPUpdateServer implementation. So in this project we have implemented one. Whenever ESP32 provides an official HTTPUpdateServer, this local implementation will be removed.
-  
+
 ## TODO / Feature requests
   - We might want to add a "verify password" field.
   - Possibility to organize blocks of config items to lists. (E.g. provide more SSIDs with passwords as a connection option.)
@@ -75,7 +76,7 @@ to ESP32. There are two major problems.
 
 ## Known issues
   - It is reported, that there might be unstable working with different lwIP variants. If you experiment serious problems, try to select another lwIP variant for your board in the Tools menu! (Tested with "v2 Lower Memory" version.)
-  
+
 ## Credits
 Although IotWebConf started without being influenced by any other solutions, in the final code you can find some segments borrowed from the WiFiManager library.
   - https://github.com/tzapu/WiFiManager

--- a/examples/IotWebConfHttps/IotWebConfHttps.ino
+++ b/examples/IotWebConfHttps/IotWebConfHttps.ino
@@ -1,0 +1,90 @@
+#include <ESP8266WiFi.h>
+#include <ESP8266HTTPClient.h>
+#include <ESP8266WebServer.h>
+#include <ESP8266WebServerSecure.h>
+#include <ESP8266HTTPUpdateServer.h>
+
+#include <IotWebConf.h>
+
+const char SSL_key[] PROGMEM = R"=====(
+YOUR PRIVATE KEY HERE
+)=====";
+
+const char SSL_cert[] PROGMEM = R"=====(
+YOUR SERT FILE HERE
+)=====";
+
+// -- Initial name of the Thing. Used e.g. as SSID of the own Access Point.
+const char thingName[] = "testThing";
+
+// -- Initial password to connect to the Thing, when it creates an own Access Point.
+const char wifiInitialApPassword[] = "smrtTHNG8266";
+
+// -- Configuration specific key. The value should be modified if config structure was changed.
+#define CONFIG_VERSION "dem1"
+
+// -- When CONFIG_PIN is pulled to ground on startup, the Thing will use the initial
+//      password to buld an AP. (E.g. in case of lost password)
+#define CONFIG_PIN D2
+
+DNSServer dnsServer;
+WebServer serverHTTP(80);
+WebServerSecure server(443);
+HTTPUpdateServerSecure httpUpdater;
+
+IotWebConfSecure iotWebConf(thingName, &dnsServer, &server, wifiInitialApPassword, CONFIG_VERSION);
+
+
+void secureRedirect() {
+  serverHTTP.sendHeader("Location", String("https://") + WiFi.localIP().toString(), true);
+  serverHTTP.send(301, "text/plain", "");
+}
+
+void handleRoot()
+{
+  // -- Let IotWebConf test and handle captive portal requests.
+  if (iotWebConf.handleCaptivePortal())
+  {
+    // -- Captive portal request were already served.
+    return;
+  }
+  String s = "<!DOCTYPE html><html lang=\"en\"><head><meta name=\"viewport\" content=\"width=device-width, initial-scale=1, user-scalable=no\"/>";
+  s += "<title>IotWebConf 04 Update Server</title></head><body>Hello world!";
+  s += "Go to <a href='config'>configure page</a> to change values.";
+  s += "</body></html>\n";
+
+  server.send(200, "text/html", s);
+}
+
+void setup() {
+  // put your setup code here, to run once:
+
+  Serial.begin(115200);
+  Serial.println();
+  Serial.println("Starting up...");
+
+  iotWebConf.setConfigPin(CONFIG_PIN);
+  iotWebConf.setupUpdateServer(&httpUpdater);
+
+  // -- Initializing the configuration.
+  iotWebConf.init();
+
+  serverHTTP.on("/", secureRedirect);
+  serverHTTP.begin();
+
+  server.getServer().setRSACert(new BearSSL::X509List(SSL_cert), new BearSSL::PrivateKey(SSL_key));
+
+  // -- Set up required URL handlers on the web server.
+  server.on("/", handleRoot);
+  server.on("/config", []{ iotWebConf.handleConfig(); });
+  server.onNotFound([](){ iotWebConf.handleNotFound(); });
+  server.begin();
+
+  Serial.println("Ready.");
+
+}
+
+void loop() {
+  serverHTTP.handleClient();
+  iotWebConf.doLoop();
+}

--- a/src/IotWebConf-impl.h
+++ b/src/IotWebConf-impl.h
@@ -11,8 +11,6 @@
 
 #include <EEPROM.h>
 
-#include "IotWebConf.h"
-
 #ifdef IOTWEBCONF_CONFIG_USE_MDNS
 # ifdef ESP8266
 #  include <ESP8266mDNS.h>
@@ -68,8 +66,9 @@ IotWebConfSeparator::IotWebConfSeparator(const char* label)
 
 ////////////////////////////////////////////////////////////////
 
-IotWebConf::IotWebConf(
-    const char* defaultThingName, DNSServer* dnsServer, WebServer* server,
+template <class WebServerClass, class HTTPUpdateServerClass>
+IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::IotWebConfTemplate(
+    const char* defaultThingName, DNSServer* dnsServer, WebServerClass* server,
     const char* initialApPassword, const char* configVersion)
 {
   strncpy(this->_thingName, defaultThingName, IOTWEBCONF_WORD_LEN);
@@ -91,30 +90,35 @@ IotWebConf::IotWebConf(
   this->addParameter(&this->_apTimeoutParameter);
 }
 
-char* IotWebConf::getThingName()
+template <class WebServerClass, class HTTPUpdateServerClass>
+char* IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::getThingName()
 {
   return this->_thingName;
 }
 
-void IotWebConf::setConfigPin(int configPin)
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::setConfigPin(int configPin)
 {
   this->_configPin = configPin;
 }
 
-void IotWebConf::setStatusPin(int statusPin, int statusOnLevel)
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::setStatusPin(int statusPin, int statusOnLevel)
 {
   this->_statusPin = statusPin;
   this->_statusOnLevel = statusOnLevel;
 }
 
-void IotWebConf::setupUpdateServer(
-    HTTPUpdateServer* updateServer, const char* updatePath)
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::setupUpdateServer(
+    HTTPUpdateServerClass* updateServer, const char* updatePath)
 {
   this->_updateServer = updateServer;
   this->_updatePath = updatePath;
 }
 
-boolean IotWebConf::init()
+template <class WebServerClass, class HTTPUpdateServerClass>
+boolean IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::init()
 {
   // -- Setup pins.
   if (this->_configPin >= 0)
@@ -159,7 +163,8 @@ boolean IotWebConf::init()
 
 //////////////////////////////////////////////////////////////////
 
-bool IotWebConf::addParameter(IotWebConfParameter* parameter)
+template <class WebServerClass, class HTTPUpdateServerClass>
+bool IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::addParameter(IotWebConfParameter* parameter)
 {
 /*
 #ifdef IOTWEBCONF_DEBUG_TO_SERIAL
@@ -184,7 +189,8 @@ bool IotWebConf::addParameter(IotWebConfParameter* parameter)
   return true;
 }
 
-int IotWebConf::configInit()
+template <class WebServerClass, class HTTPUpdateServerClass>
+int IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::configInit()
 {
   int size = 0;
   IotWebConfParameter* current = this->_firstParameter;
@@ -204,7 +210,8 @@ int IotWebConf::configInit()
 /**
  * Load the configuration from the eeprom.
  */
-boolean IotWebConf::configLoad()
+template <class WebServerClass, class HTTPUpdateServerClass>
+boolean IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::configLoad()
 {
   int size = this->configInit();
   EEPROM.begin(
@@ -269,7 +276,8 @@ boolean IotWebConf::configLoad()
   EEPROM.end();
 }
 
-void IotWebConf::configSave()
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::configSave()
 {
   int size = this->configInit();
   if (this->_configSavingCallback != NULL)
@@ -323,14 +331,16 @@ void IotWebConf::configSave()
   }
 }
 
-void IotWebConf::readEepromValue(int start, char* valueBuffer, int length)
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::readEepromValue(int start, char* valueBuffer, int length)
 {
   for (int t = 0; t < length; t++)
   {
     *((char*)valueBuffer + t) = EEPROM.read(start + t);
   }
 }
-void IotWebConf::writeEepromValue(int start, char* valueBuffer, int length)
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::writeEepromValue(int start, char* valueBuffer, int length)
 {
   for (int t = 0; t < length; t++)
   {
@@ -338,7 +348,8 @@ void IotWebConf::writeEepromValue(int start, char* valueBuffer, int length)
   }
 }
 
-boolean IotWebConf::configTestVersion()
+template <class WebServerClass, class HTTPUpdateServerClass>
+boolean IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::configTestVersion()
 {
   for (byte t = 0; t < IOTWEBCONF_CONFIG_VERSION_LENGTH; t++)
   {
@@ -350,7 +361,8 @@ boolean IotWebConf::configTestVersion()
   return true;
 }
 
-void IotWebConf::configSaveConfigVersion()
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::configSaveConfigVersion()
 {
   for (byte t = 0; t < IOTWEBCONF_CONFIG_VERSION_LENGTH; t++)
   {
@@ -358,34 +370,40 @@ void IotWebConf::configSaveConfigVersion()
   }
 }
 
-void IotWebConf::setWifiConnectionCallback(std::function<void()> func)
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::setWifiConnectionCallback(std::function<void()> func)
 {
   this->_wifiConnectionCallback = func;
 }
 
-void IotWebConf::setConfigSavingCallback(std::function<void(int size)> func)
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::setConfigSavingCallback(std::function<void(int size)> func)
 {
   this->_configSavingCallback = func;
 }
 
-void IotWebConf::setConfigSavedCallback(std::function<void()> func)
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::setConfigSavedCallback(std::function<void()> func)
 {
   this->_configSavedCallback = func;
 }
 
-void IotWebConf::setFormValidator(std::function<boolean()> func)
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::setFormValidator(std::function<boolean()> func)
 {
   this->_formValidator = func;
 }
 
-void IotWebConf::setWifiConnectionTimeoutMs(unsigned long millis)
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::setWifiConnectionTimeoutMs(unsigned long millis)
 {
   this->_wifiConnectionTimeoutMs = millis;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void IotWebConf::handleConfig()
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::handleConfig()
 {
   if (this->_state == IOTWEBCONF_STATE_ONLINE)
   {
@@ -608,7 +626,8 @@ void IotWebConf::handleConfig()
   }
 }
 
-void IotWebConf::readParamValue(
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::readParamValue(
     const char* paramName, char* target, unsigned int len)
 {
   String value = this->_server->arg(paramName);
@@ -621,7 +640,8 @@ void IotWebConf::readParamValue(
   value.toCharArray(target, len);
 }
 
-boolean IotWebConf::validateForm()
+template <class WebServerClass, class HTTPUpdateServerClass>
+boolean IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::validateForm()
 {
   // -- Clean previous error messages.
   IotWebConfParameter* current = this->_firstParameter;
@@ -664,7 +684,8 @@ boolean IotWebConf::validateForm()
   return valid;
 }
 
-void IotWebConf::handleNotFound()
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::handleNotFound()
 {
   if (this->handleCaptivePortal())
   {
@@ -706,7 +727,8 @@ void IotWebConf::handleNotFound()
  * Return true in that case so the page handler do not try to handle the request
  * again. (Code from WifiManager project.)
  */
-boolean IotWebConf::handleCaptivePortal()
+template <class WebServerClass, class HTTPUpdateServerClass>
+boolean IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::handleCaptivePortal()
 {
   String host = this->_server->hostHeader();
   String thingName = String(this->_thingName);
@@ -729,7 +751,8 @@ boolean IotWebConf::handleCaptivePortal()
 }
 
 /** Is this an IP? */
-boolean IotWebConf::isIp(String str)
+template <class WebServerClass, class HTTPUpdateServerClass>
+boolean IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::isIp(String str)
 {
   for (size_t i = 0; i < str.length(); i++)
   {
@@ -743,7 +766,8 @@ boolean IotWebConf::isIp(String str)
 }
 
 /** IP to String? */
-String IotWebConf::toStringIp(IPAddress ip)
+template <class WebServerClass, class HTTPUpdateServerClass>
+String IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::toStringIp(IPAddress ip)
 {
   String res = "";
   for (int i = 0; i < 3; i++)
@@ -756,7 +780,8 @@ String IotWebConf::toStringIp(IPAddress ip)
 
 /////////////////////////////////////////////////////////////////////////////////
 
-void IotWebConf::delay(unsigned long m)
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::delay(unsigned long m)
 {
   unsigned long delayStart = millis();
   while (m > millis() - delayStart)
@@ -768,7 +793,8 @@ void IotWebConf::delay(unsigned long m)
   }
 }
 
-void IotWebConf::doLoop()
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::doLoop()
 {
   doBlink();
   yield(); // -- Yield should not be necessary, but cannot hurt eather.
@@ -830,7 +856,8 @@ void IotWebConf::doLoop()
 /**
  * What happens, when a state changed...
  */
-void IotWebConf::changeState(byte newState)
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::changeState(byte newState)
 {
   switch (newState)
   {
@@ -877,7 +904,8 @@ void IotWebConf::changeState(byte newState)
 /**
  * What happens, when a state changed...
  */
-void IotWebConf::stateChanged(byte oldState, byte newState)
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::stateChanged(byte oldState, byte newState)
 {
 //  updateOutput();
   switch (newState)
@@ -947,7 +975,8 @@ void IotWebConf::stateChanged(byte oldState, byte newState)
   }
 }
 
-void IotWebConf::checkApTimeout()
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::checkApTimeout()
 {
   if ( !mustStayInApMode() )
   {
@@ -966,7 +995,8 @@ void IotWebConf::checkApTimeout()
  * If so, we must not change state. But when our guest leaved, we can
  * immediately move on.
  */
-void IotWebConf::checkConnection()
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::checkConnection()
 {
   if ((this->_apConnectionStatus == IOTWEBCONF_AP_CONNECTION_STATE_NC) &&
       (WiFi.softAPgetStationNum() > 0))
@@ -988,7 +1018,8 @@ void IotWebConf::checkConnection()
   }
 }
 
-boolean IotWebConf::checkWifiConnection()
+template <class WebServerClass, class HTTPUpdateServerClass>
+boolean IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::checkWifiConnection()
 {
   if (WiFi.status() != WL_CONNECTED)
   {
@@ -1023,7 +1054,8 @@ boolean IotWebConf::checkWifiConnection()
   return true;
 }
 
-void IotWebConf::setupAp()
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::setupAp()
 {
   WiFi.mode(WIFI_AP);
 
@@ -1069,7 +1101,8 @@ void IotWebConf::setupAp()
   this->_dnsServer->start(IOTWEBCONF_DNS_PORT, "*", WiFi.softAPIP());
 }
 
-void IotWebConf::stopAp()
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::stopAp()
 {
   WiFi.softAPdisconnect(true);
   WiFi.mode(WIFI_STA);
@@ -1077,7 +1110,8 @@ void IotWebConf::stopAp()
 
 ////////////////////////////////////////////////////////////////////
 
-void IotWebConf::blink(unsigned long repeatMs, byte dutyCyclePercent)
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::blink(unsigned long repeatMs, byte dutyCyclePercent)
 {
   if (repeatMs == 0)
   {
@@ -1090,26 +1124,30 @@ void IotWebConf::blink(unsigned long repeatMs, byte dutyCyclePercent)
   }
 }
 
-void IotWebConf::fineBlink(unsigned long onMs, unsigned long offMs)
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::fineBlink(unsigned long onMs, unsigned long offMs)
 {
   this->_blinkOnMs = onMs;
   this->_blinkOffMs = offMs;
 }
 
-void IotWebConf::stopCustomBlink()
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::stopCustomBlink()
 {
   this->_blinkOnMs = this->_internalBlinkOnMs;
   this->_blinkOffMs = this->_internalBlinkOffMs;
 }
 
-void IotWebConf::blinkInternal(unsigned long repeatMs, byte dutyCyclePercent)
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::blinkInternal(unsigned long repeatMs, byte dutyCyclePercent)
 {
   this->blink(repeatMs, dutyCyclePercent);
   this->_internalBlinkOnMs = this->_blinkOnMs;
   this->_internalBlinkOffMs = this->_blinkOffMs;
 }
 
-void IotWebConf::doBlink()
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::doBlink()
 {
   if (IOTWEBCONF_STATUS_ENABLED)
   {
@@ -1125,7 +1163,8 @@ void IotWebConf::doBlink()
   }
 }
 
-void IotWebConf::forceApMode(boolean doForce)
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::forceApMode(boolean doForce)
 {
   if (this->_forceApMode == doForce)
   {
@@ -1156,20 +1195,23 @@ void IotWebConf::forceApMode(boolean doForce)
         IOTWEBCONF_DEBUG_LINE(F("Stopping AP mode force."));
         this->changeState(IOTWEBCONF_STATE_CONNECTING);
       }
-      
+
     }
   }
 }
 
-boolean IotWebConf::connectAp(const char* apName, const char* password)
+template <class WebServerClass, class HTTPUpdateServerClass>
+boolean IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::connectAp(const char* apName, const char* password)
 {
   return WiFi.softAP(apName, password);
 }
-void IotWebConf::connectWifi(const char* ssid, const char* password)
+template <class WebServerClass, class HTTPUpdateServerClass>
+void IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::connectWifi(const char* ssid, const char* password)
 {
   WiFi.begin(ssid, password);
 }
-IotWebConfWifiAuthInfo* IotWebConf::handleConnectWifiFailure()
+template <class WebServerClass, class HTTPUpdateServerClass>
+IotWebConfWifiAuthInfo* IotWebConfTemplate<WebServerClass, HTTPUpdateServerClass>::handleConnectWifiFailure()
 {
   return NULL;
 }

--- a/src/IotWebConfCompatibility-impl.h
+++ b/src/IotWebConfCompatibility-impl.h
@@ -19,7 +19,6 @@
 /**
  * NOTE: Lines starting with /// are changed by IotWebConf
  */
-#include "IotWebConfCompatibility.h"
 
 static const char serverIndex[] PROGMEM =
   R"(<html><body><form method='POST' action='' enctype='multipart/form-data'>
@@ -27,10 +26,11 @@ static const char serverIndex[] PROGMEM =
                   <input type='submit' value='Update'>
                </form>
          </body></html>)";
-static const char successResponse[] PROGMEM = 
+static const char successResponse[] PROGMEM =
   "<META http-equiv=\"refresh\" content=\"15;URL=/\">Update Success! Rebooting...\n";
 
-HTTPUpdateServer::HTTPUpdateServer(bool serial_debug)
+template <class WebServerClass>
+HTTPUpdateServerTemplate<WebServerClass>::HTTPUpdateServerTemplate(bool serial_debug)
 {
   _serial_output = serial_debug;
   _server = NULL;
@@ -39,7 +39,8 @@ HTTPUpdateServer::HTTPUpdateServer(bool serial_debug)
   _authenticated = false;
 }
 
-void HTTPUpdateServer::setup(WebServer *server, const String& path, const String& username, const String& password)
+template <class WebServerClass>
+void HTTPUpdateServerTemplate<WebServerClass>::setup(WebServerClass *server, const String& path, const String& username, const String& password)
 {
     _server = server;
     _username = username;
@@ -110,11 +111,13 @@ void HTTPUpdateServer::setup(WebServer *server, const String& path, const String
     });
 }
 
-void HTTPUpdateServer::_setUpdaterError()
+template <class WebServerClass>
+void HTTPUpdateServerTemplate<WebServerClass>::_setUpdaterError()
 {
   if (_serial_output) Update.printError(Serial);
   StreamString str;
   Update.printError(str);
   _updaterError = str.c_str();
 }
+
 #endif

--- a/src/IotWebConfCompatibility.h
+++ b/src/IotWebConfCompatibility.h
@@ -23,6 +23,8 @@
 #ifdef ESP8266
 # define WebServer ESP8266WebServer
 # define HTTPUpdateServer ESP8266HTTPUpdateServer
+# define WebServerSecure BearSSL::ESP8266WebServerSecure
+# define HTTPUpdateServerSecure BearSSL::ESP8266HTTPUpdateServerSecure
 #endif
 
 
@@ -49,28 +51,30 @@
 #define emptyString F("")
 
 class WebServer;
+class WebServerSecure;
 
-class HTTPUpdateServer
+template <class WebServerClass>
+class HTTPUpdateServerTemplate
 {
   public:
-    HTTPUpdateServer(bool serial_debug=false);
+    HTTPUpdateServerTemplate(bool serial_debug=false);
 
-    void setup(WebServer *server)
+    void setup(WebServerClass *server)
     {
       setup(server, emptyString, emptyString);
     }
 
-    void setup(WebServer *server, const String& path)
+    void setup(WebServerClass *server, const String& path)
     {
       setup(server, path, emptyString, emptyString);
     }
 
-    void setup(WebServer *server, const String& username, const String& password)
+    void setup(WebServerClass *server, const String& username, const String& password)
     {
       setup(server, "/update", username, password);
     }
 
-    void setup(WebServer *server, const String& path, const String& username, const String& password);
+    void setup(WebServerClass *server, const String& path, const String& username, const String& password);
 
     void updateCredentials(const String& username, const String& password)
     {
@@ -83,12 +87,17 @@ class HTTPUpdateServer
 
   private:
     bool _serial_output;
-    WebServer *_server;
+    WebServerClass *_server;
     String _username;
     String _password;
     bool _authenticated;
     String _updaterError;
 };
+
+using HTTPUpdateServer = HTTPUpdateServerTemplate<WebServer>;
+using HTTPUpdateServerSecure = HTTPUpdateServerTemplate<WebServerSecure>;
+
+#include "IotWebConfCompatibility-impl.h"
 #endif
 
 #endif


### PR DESCRIPTION
- Changed IotWebConf to be a generic template so the webserver/updateserver could be swapped to the secure versions
- Added an example of using it
- Changed ESP32 update server implementation to a generic that can accept the secure version of the server

**NOTES**
- Not tested on an ESP32 as I don't own one, but it _should work_.
- You have to provide your own certs (obviously)
- Heavily tested on my ESP8266s that I use for my home security system and solar battery monitor.

**COMPATIBILITY**
- Should be drop in compatible with no changes.