### PR TITLE
Make config and Wifi credentials available

### DIFF
--- a/src/IotWebConf.h
+++ b/src/IotWebConf.h
@@ -431,6 +431,12 @@ public:
    */
   unsigned long getApTimeoutMs() { return this->_apTimeoutMs; };
 
+    /**
+   * Returns the current WiFi authentication credentials. These are usually the configured ones,
+   * but might be overwritten by setWifiConnectionFailedHandler().
+   */
+  WifiAuthInfo getWifiAuthInfo() { return _wifiAuthInfo; };
+
   /**
    * Resets the authentication credentials for WiFi connection to the configured one.
    * With the return value of setWifiConnectionFailedHandler() one can provide alternative connection settings,

--- a/src/IotWebConf.h
+++ b/src/IotWebConf.h
@@ -499,6 +499,12 @@ public:
   void saveConfig();
 
   /**
+   * Loads all configuration from the EEPROM without initializing the system.
+   * Will return false, if no configuration (with specified config version) was found in the EEPROM.
+   */
+  bool loadConfig();
+
+  /**
    * With this method you can override the default HTML format provider to
    * provide custom HTML segments.
    */
@@ -574,7 +580,6 @@ private:
   HtmlFormatProvider* htmlFormatProvider = &htmlFormatProviderInstance;
 
   int initConfig();
-  bool loadConfig();
   bool testConfigVersion();
   void saveConfigVersion();
   void readEepromValue(int start, byte* valueBuffer, int length);


### PR DESCRIPTION
Little bit of background: I'm currently building a temperature logger for myself which should later run on battery. I plan to have a config mode using IotWebConf where I configure things like Wifi credentials, Influx parameters and measurement interval. I'll probably trigger config mode using the DoubleResetDetect library or some pin.

But most of the time, I just want to consume as little energy as possible, so I'll just trigger a Wifi connection, do my measurements, make sure that the Wifi connection is established by then and push the results to my server. So I won't have an AP or web server running all the time and would like to avoid potential overhead. I really just want the configured values and manage everything else myself. I feel that these two changes help with that.