### PR TITLE
Fixed broken uncheck of checkboxes

### DIFF
--- a/src/IotWebConfParameter.cpp
+++ b/src/IotWebConfParameter.cpp
@@ -230,6 +230,8 @@ void Parameter::update(WebRequestWrapper* webRequestWrapper)
     String newValue = webRequestWrapper->arg(this->getId());
     this->update(newValue);
   }
+  else if (this->updateEmpty())
+    this->update("");
 }
 void Parameter::clearErrorMessage()
 {

--- a/src/IotWebConfParameter.h
+++ b/src/IotWebConfParameter.h
@@ -177,6 +177,7 @@ protected:
   void loadValue(std::function<void(SerializationData* serializationData)> doLoad) override;
   virtual void update(WebRequestWrapper* webRequestWrapper) override;
   virtual void update(String newValue);
+  virtual bool updateEmpty() { return false; }
   void clearErrorMessage() override;
 
 private:
@@ -308,6 +309,7 @@ protected:
   virtual String renderHtml(
     bool dataArrived, bool hasValueFromPost, String valueFromPost) override;
   virtual void update(String newValue) override;
+  virtual bool updateEmpty() { return true; };
 
 private:
   friend class IotWebConf;


### PR DESCRIPTION
Added a method to indicate if a parameter shall be
updated even if parameter is missing in the web POST request.
When unchecking a checkbox, nothing is sent for
that checkbox in the web request and thus it was
not possible to save when a checkbox had been unchecked,
resulting in checkboxes always being checked.