### PR TITLE
Fix text parameters being truncated due to wrong length limit

### DIFF
--- a/src/IotWebConfParameter.cpp
+++ b/src/IotWebConfParameter.cpp
@@ -272,7 +272,7 @@ String TextParameter::renderHtml(
   pitem.replace("{t}", type);
   pitem.replace("{i}", current->getId());
   pitem.replace("{p}", current->placeholder == NULL ? "" : current->placeholder);
-  snprintf(parLength, 5, "%d", current->getLength());
+  snprintf(parLength, 5, "%d", current->getLength()-1);
   pitem.replace("{l}", parLength);
   if (hasValueFromPost)
   {


### PR DESCRIPTION
There is a bug that causes the parameters to be truncated after they are saved. This is because the max length set in the parameter settings is the size of the buffer, but in the HTML the max length does not count for the null termination character.

How to reproduce:
 * Upload the IotWebConf03CustomParameters.ino example to the board.
 * Go to the config page and fill the "string param" with 128 characters (until the html limit)
 * Save
The last character gets trucated as the space is needed in the buffer for the termination character.

The solution proposed sets the html limit to 1 character less to take into account the termination character.

It's basically the same bug that existed before and was re-introduced after the parameter rewrite: https://github.com/prampec/IotWebConf/pull/95