### PR TITLE
Added a simple optional callback for state changes.

### DIFF
--- a/src/IotWebConf.cpp
+++ b/src/IotWebConf.cpp
@@ -256,6 +256,11 @@ void IotWebConf::setConfigSavedCallback(std::function<void()> func)
   this->_configSavedCallback = func;
 }
 
+void IotWebConf::setStateChangedCallback(std::function<void(byte oldState, byte newState)> func)
+{
+  this->_stateChangedCallback = func;
+}
+
 void IotWebConf::setFormValidator(
   std::function<bool(WebRequestWrapper* webRequestWrapper)> func)
 {
@@ -623,6 +628,10 @@ void IotWebConf::changeState(byte newState)
   byte oldState = this->_state;
   this->_state = newState;
   this->stateChanged(oldState, newState);
+  if (this->_stateChangedCallback != nullptr) 
+  {
+    this->_stateChangedCallback(oldState, newState);
+  }
 #ifdef IOTWEBCONF_DEBUG_TO_SERIAL
   Serial.print("State changed from: ");
   Serial.print(oldState);

--- a/src/IotWebConf.h
+++ b/src/IotWebConf.h
@@ -291,6 +291,12 @@ public:
   void setConfigSavedCallback(std::function<void()> func);
 
   /**
+   * Specify a callback method, that will be called when ever the state is changed.
+   * See IOTWEBCONF_STATE_* for possible values
+   */
+  void setStateChangedCallback(std::function<void(byte oldState, byte newState)> func);
+
+  /**
    * Specify a callback method, that will be called when form validation is required.
    * If the method will return false, the configuration will not be saved.
    * Should be called before init()!
@@ -572,6 +578,7 @@ private:
   std::function<void()> _wifiConnectionCallback = nullptr;
   std::function<void(int)> _configSavingCallback = nullptr;
   std::function<void()> _configSavedCallback = nullptr;
+  std::function<void(byte oldState, byte newState)> _stateChangedCallback = nullptr;
   std::function<bool(WebRequestWrapper* webRequestWrapper)> _formValidator = nullptr;
   std::function<void(const char*, const char*)> _apConnectionHandler =
       &(IotWebConf::connectAp);


### PR DESCRIPTION
I needed a simple way to track what "state" the IotWebConfig instance was in, so I could easily present the necessary status screen to the users on a small OLED.  In my project, I have the wifi status, and the AP status screen showing very different information.  Thought this would be a nice simple addition to your library.