### PR TITLE
Fix WiFi.mode() if skipApStartup() is in use

### DIFF
--- a/src/IotWebConf.cpp
+++ b/src/IotWebConf.cpp
@@ -691,7 +691,8 @@ void IotWebConf::stateChanged(byte oldState, byte newState)
 #endif
       break;
     case IOTWEBCONF_STATE_CONNECTING:
-      if ((oldState == IOTWEBCONF_STATE_AP_MODE) ||
+      if ((oldState == IOTWEBCONF_STATE_BOOT) ||
+          (oldState == IOTWEBCONF_STATE_AP_MODE) ||
           (oldState == IOTWEBCONF_STATE_NOT_CONFIGURED))
       {
         stopAp();


### PR DESCRIPTION
If skipApStartup() called before init(), WiFi.mode not set - I can see and connect to soft AP while device actually already connected to WiFi