### PR TITLE
Fix off-by-one in string length for InputParameter

### DIFF
--- a/src/IotWebConfTParameter.h
+++ b/src/IotWebConfTParameter.h
@@ -419,7 +419,7 @@ protected:
     if (length > 0)
     {
       char parLength[11];
-      snprintf(parLength, 11, "%d", length);
+      snprintf(parLength, 11, "%d", length - 1); // To allow "\0" at the end of the string.
       String maxLength = String("maxlength=") + parLength;
       pitem.replace("{l}", maxLength);
     }


### PR DESCRIPTION
Should fix #242.

TextTParameter can be typed correctly, and this change doesn't affect `ColorTParameter`, `DateTParameter` or `TimeTParameter` since their definition all include a terminating NULL character.