### PR TITLE
Set order of WiFi.mode and WiFi.setHostname

### DIFF
--- a/src/IotWebConf.cpp
+++ b/src/IotWebConf.cpp
@@ -728,8 +728,14 @@ void IotWebConf::stateChanged(NetworkState oldState, NetworkState newState)
       Serial.println(this->_wifiConnectionTimeoutMs);
 #endif
       this->_wifiConnectionStart = millis();
+      // The order of WiFi.mode and WiFi.setHostname matters based on the platform
+#ifdef ESP8266
       WiFi.mode(WIFI_STA);
-      WiFi.setHostname(this->_thingName); // Hostname needs to be set right before WiFi.begin
+      WiFi.setHostname(this->_thingName);
+#elif defined(ESP32)
+      WiFi.setHostname(this->_thingName);
+      WiFi.mode(WIFI_STA);
+#endif
       this->_wifiConnectionHandler(
           this->_wifiAuthInfo.ssid, this->_wifiAuthInfo.password);
       break;


### PR DESCRIPTION
The order of WiFi.mode and WiFi.setHostname seems to matter based on the platform. Seems odd, but I was able to replicate the results on an ESP8266 and ESP32. If they weren't in the correct order, the DHCP request wouldn't use `this->_thingName` and would use the default ESP hostname ie: `ESP-XXXXXX`