### PR TITLE
mDNS on demand activation/deactivation

### DIFF
--- a/src/IotWebConf.h
+++ b/src/IotWebConf.h
@@ -242,6 +242,11 @@ public:
   void doLoop();
 
   /**
+   * Used to ending mDNS after network failure.
+   */
+  void endMDns();
+
+  /**
    * Each WebServer URL handler method should start with calling this method.
    * If this method return true, the request was already served by it.
    */

--- a/src/IotWebConf.h
+++ b/src/IotWebConf.h
@@ -242,11 +242,6 @@ public:
   void doLoop();
 
   /**
-   * Used to ending mDNS after network failure.
-   */
-  void endMDns();
-
-  /**
    * Each WebServer URL handler method should start with calling this method.
    * If this method return true, the request was already served by it.
    */
@@ -654,6 +649,7 @@ private:
   bool checkWifiConnection();
   void setupAp();
   void stopAp();
+  void endMDns(NetworkState oldState);
 
   static bool connectAp(const char* apName, const char* password);
   static void connectWifi(const char* ssid, const char* password);


### PR DESCRIPTION
Added starting mDNS after WiFi successfully returns an IP address. Also added shutdown of mDNS when WiFi connection is lost. Note, there is no need for mDNS support in AP mode because the portal is captive.